### PR TITLE
Add Life Harmony wheel and refresh navigation

### DIFF
--- a/about.html
+++ b/about.html
@@ -11,10 +11,10 @@
 <header class="site-header">
   <a class="brand" href="/"><img src="assets/logo.svg" alt=""><span>Harmony Sheets</span></a>
   <nav class="main-nav">
-    <a href="products.html">Shop</a>
+    <a href="products.html">Browse Life Harmony Apps/Tools</a>
     <a href="bundles.html">Bundles</a>
     <a href="faq.html">FAQ / Support</a>
-    <a class="active" href="about.html">About</a>
+    <a href="about.html">About</a>
   </nav>
 </header>
 

--- a/bundles.html
+++ b/bundles.html
@@ -11,8 +11,8 @@
 <header class="site-header">
   <a class="brand" href="/"><img src="assets/logo.svg" alt=""><span>Harmony Sheets</span></a>
   <nav class="main-nav">
-    <a href="products.html">Shop</a>
-    <a class="active" href="bundles.html">Bundles</a>
+    <a href="products.html">Browse Life Harmony Apps/Tools</a>
+    <a href="bundles.html">Bundles</a>
     <a href="faq.html">FAQ / Support</a>
     <a href="about.html">About</a>
   </nav>

--- a/faq.html
+++ b/faq.html
@@ -11,9 +11,9 @@
 <header class="site-header">
   <a class="brand" href="/"><img src="assets/logo.svg" alt=""><span>Harmony Sheets</span></a>
   <nav class="main-nav">
-    <a href="products.html">Shop</a>
+    <a href="products.html">Browse Life Harmony Apps/Tools</a>
     <a href="bundles.html">Bundles</a>
-    <a class="active" href="faq.html">FAQ / Support</a>
+    <a href="faq.html">FAQ / Support</a>
     <a href="about.html">About</a>
   </nav>
 </header>

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <title>Harmony Sheets — Calm, App-like Spreadsheets (One-Time Purchase)</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Budgets, planners, Pomodoro, and more. One-time purchase. No subscriptions. You own the tool.">
+  <meta name="description" content="Explore the Life Harmony Wheel — Love, Career, Health, Finances, Fun, Family, Environment, and Spirituality. App-like spreadsheets with one-time pricing.">
   <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="style.css">
 </head>
@@ -12,12 +12,7 @@
 <header class="site-header">
   <a class="brand" href="/"><img src="assets/logo.svg" alt=""><span>Harmony Sheets</span></a>
   <nav class="main-nav">
-    <a href="products.html?cat=finance" data-cat="finance">Budgets & Personal Finance</a>
-    <a href="products.html?cat=productivity" data-cat="productivity">Productivity & Projects</a>
-    <a href="products.html?cat=health" data-cat="health">Health & Fitness</a>
-    <a href="products.html?cat=food" data-cat="food">Food & Nutrition</a>
-    <a href="products.html?cat=creative" data-cat="creative">Creative & Learning</a>
-    <a href="products.html?cat=planning" data-cat="planning">Planning & Calendars</a>
+    <a href="products.html">Browse Life Harmony Apps/Tools</a>
     <a href="bundles.html">Bundles</a>
     <a href="faq.html">FAQ / Support</a>
     <a href="about.html">About</a>
@@ -35,13 +30,65 @@
     </div>
   </section>
 
-  <section class="categories">
-    <a class="cat finance" href="products.html?cat=finance"><h3>Budgets & Personal Finance</h3></a>
-    <a class="cat productivity" href="products.html?cat=productivity"><h3>Productivity, To-Do & Projects</h3></a>
-    <a class="cat health" href="products.html?cat=health"><h3>Health & Fitness</h3></a>
-    <a class="cat food" href="products.html?cat=food"><h3>Food & Nutrition</h3></a>
-    <a class="cat creative" href="products.html?cat=creative"><h3>Creative & Learning</h3></a>
-    <a class="cat planning" href="products.html?cat=planning"><h3>Planning & Calendars</h3></a>
+  <section id="life-wheel" class="life-wheel">
+    <div class="life-wheel__intro">
+      <h2>Find your balance with the Life Harmony Wheel</h2>
+      <p>Every template is designed to support one of the eight core areas of a flourishing life. Hover or focus on a slice to learn how Harmony Sheets can guide you forward.</p>
+    </div>
+    <div class="life-wheel__layout">
+      <div class="life-wheel__graphic">
+        <svg viewBox="0 0 360 360" role="img" aria-labelledby="life-wheel-title">
+          <title id="life-wheel-title">Life Harmony Wheel categories</title>
+          <g class="life-wheel__segments" transform="rotate(-22.5 180 180)">
+            <a class="life-wheel__slice-link" data-area="love" href="products.html?area=love">
+              <title>Love &amp; Romantic Relationships</title>
+              <path class="life-wheel__slice" fill="#F471B5" d="M 180 180 L 180.0 20.0 A 160 160 0 0 1 293.137 66.863 Z"/>
+            </a>
+            <a class="life-wheel__slice-link" data-area="career" href="products.html?area=career">
+              <title>Career, Growth &amp; Learning</title>
+              <path class="life-wheel__slice" fill="#A855F7" d="M 180 180 L 293.137 66.863 A 160 160 0 0 1 340.0 180.0 Z"/>
+            </a>
+            <a class="life-wheel__slice-link" data-area="health" href="products.html?area=health">
+              <title>Health &amp; Fitness</title>
+              <path class="life-wheel__slice" fill="#22C55E" d="M 180 180 L 340.0 180.0 A 160 160 0 0 1 293.137 293.137 Z"/>
+            </a>
+            <a class="life-wheel__slice-link" data-area="finances" href="products.html?area=finances">
+              <title>Finances</title>
+              <path class="life-wheel__slice" fill="#FACC15" d="M 180 180 L 293.137 293.137 A 160 160 0 0 1 180.0 340.0 Z"/>
+            </a>
+            <a class="life-wheel__slice-link" data-area="fun" href="products.html?area=fun">
+              <title>Fun &amp; Recreation</title>
+              <path class="life-wheel__slice" fill="#FB923C" d="M 180 180 L 180.0 340.0 A 160 160 0 0 1 66.863 293.137 Z"/>
+            </a>
+            <a class="life-wheel__slice-link" data-area="family" href="products.html?area=family">
+              <title>Family &amp; Friends</title>
+              <path class="life-wheel__slice" fill="#60A5FA" d="M 180 180 L 66.863 293.137 A 160 160 0 0 1 20.0 180.0 Z"/>
+            </a>
+            <a class="life-wheel__slice-link" data-area="environment" href="products.html?area=environment">
+              <title>Physical Environment</title>
+              <path class="life-wheel__slice" fill="#14B8A6" d="M 180 180 L 20.0 180.0 A 160 160 0 0 1 66.863 66.863 Z"/>
+            </a>
+            <a class="life-wheel__slice-link" data-area="spirituality" href="products.html?area=spirituality">
+              <title>Spirituality &amp; Community</title>
+              <path class="life-wheel__slice" fill="#6366F1" d="M 180 180 L 66.863 66.863 A 160 160 0 0 1 180.0 20.0 Z"/>
+            </a>
+          </g>
+          <circle class="life-wheel__center" cx="180" cy="180" r="72"></circle>
+          <text class="life-wheel__center-text" x="180" y="168">Life</text>
+          <text class="life-wheel__center-text" x="180" y="194">Harmony</text>
+          <text class="life-wheel__center-sub" x="180" y="222">Wheel</text>
+        </svg>
+      </div>
+      <div class="life-wheel__details" id="life-wheel-details"
+           data-default-title="Explore the Life Harmony Wheel"
+           data-default-description="Hover over a slice to discover the tools we recommend for each area of your life."
+           data-default-link="products.html"
+           data-default-cta="Browse all Life Harmony tools">
+        <h3>Explore the Life Harmony Wheel</h3>
+        <p>Hover over a slice to discover the tools we recommend for each area of your life.</p>
+        <a class="life-wheel__cta" href="products.html">Browse all Life Harmony tools</a>
+      </div>
+    </div>
   </section>
 
   <section class="grid">
@@ -55,6 +102,5 @@
 </footer>
 
 <script src="app.js"></script>
-<script>App.initHome()</script>
 </body>
 </html>

--- a/product.html
+++ b/product.html
@@ -12,12 +12,7 @@
   <header class="site-header">
     <a class="brand" href="/"><img src="assets/logo.svg" alt=""><span>Harmony Sheets</span></a>
     <nav class="main-nav">
-      <a href="products.html?cat=finance">Budgets & Personal Finance</a>
-      <a href="products.html?cat=productivity">Productivity & Projects</a>
-      <a href="products.html?cat=health">Health & Fitness</a>
-      <a href="products.html?cat=food">Food & Nutrition</a>
-      <a href="products.html?cat=creative">Creative & Learning</a>
-      <a href="products.html?cat=planning">Planning & Calendars</a>
+      <a href="products.html">Browse Life Harmony Apps/Tools</a>
       <a href="bundles.html">Bundles</a>
       <a href="faq.html">FAQ / Support</a>
       <a href="about.html">About</a>

--- a/products.html
+++ b/products.html
@@ -11,12 +11,7 @@
   <header class="site-header">
     <a class="brand" href="/"><img src="assets/logo.svg" alt=""><span>Harmony Sheets</span></a>
     <nav class="main-nav">
-      <a href="products.html?cat=finance">Budgets & Personal Finance</a>
-      <a href="products.html?cat=productivity">Productivity & Projects</a>
-      <a href="products.html?cat=health">Health & Fitness</a>
-      <a href="products.html?cat=food">Food & Nutrition</a>
-      <a href="products.html?cat=creative">Creative & Learning</a>
-      <a href="products.html?cat=planning">Planning & Calendars</a>
+      <a href="products.html">Browse Life Harmony Apps/Tools</a>
       <a href="bundles.html">Bundles</a>
       <a href="faq.html">FAQ / Support</a>
       <a href="about.html">About</a>
@@ -24,7 +19,8 @@
   </header>
 
   <main class="container">
-    <h1>Our Products</h1>
+    <h1 id="products-heading">Our Products</h1>
+    <p id="products-intro" class="muted">Browse calm, app-like templates that help you build rhythm in every area of life.</p>
     <div id="products-list" class="products-grid"></div>
   </main>
 

--- a/products.json
+++ b/products.json
@@ -4,6 +4,7 @@
     "name": "Pomodoro — Productivity & Study Timer",
     "tagline": "Focus faster with structured 25–5 cycles. Calm visuals, zero clutter.",
     "price": "$9",
+    "lifeAreas": ["career", "health", "fun", "spirituality"],
     "badges": [
       "One-time purchase",
       "No login",
@@ -51,6 +52,7 @@
     "name": "Budget Dashboard — Personal Finance Tracker",
     "tagline": "Take control of your money with clarity and confidence.",
     "price": "$19",
+    "lifeAreas": ["finances", "family", "environment", "love"],
     "badges": [
       "One-time purchase",
       "Instant Google Sheets setup",
@@ -98,6 +100,7 @@
     "name": "Pomodoro Pro — Advanced Productivity System",
     "tagline": "The upgraded Pomodoro with analytics, goals, and smart focus tools.",
     "price": "$29",
+    "lifeAreas": ["career", "health", "fun", "family", "spirituality"],
     "badges": [
       "Advanced features",
       "Goal tracking",

--- a/style.css
+++ b/style.css
@@ -30,6 +30,43 @@ img{max-width:100%;display:block}
 .btn.primary{background:var(--brand);color:#fff}
 .btn.ghost{background:#eef3ff;color:var(--brand);border-color:#dbe6ff}
 
+.life-wheel{padding:64px 24px;background:linear-gradient(180deg,#f6f8ff 0%,#fff 68%)}
+.life-wheel__intro{text-align:center;max-width:720px;margin:0 auto 36px}
+.life-wheel__intro h2{margin:0 0 14px;font-size:36px;line-height:1.2}
+.life-wheel__intro p{margin:0;color:#4b5563;font-size:1.05rem}
+.life-wheel__layout{display:grid;gap:36px;align-items:center;justify-items:center;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));max-width:1100px;margin:0 auto}
+.life-wheel__graphic{width:min(420px,100%);filter:drop-shadow(0 24px 45px rgba(79,114,205,.18))}
+.life-wheel__graphic svg{width:100%;height:auto;display:block}
+.life-wheel__slice{cursor:pointer;transition:transform .3s ease,opacity .3s ease,stroke-width .3s ease;transform-origin:180px 180px;transform-box:fill-box;opacity:.92;stroke:rgba(255,255,255,.9);stroke-width:1.5}
+.life-wheel__slice-link{outline:none}
+.life-wheel__slice-link:hover .life-wheel__slice,.life-wheel__slice-link:focus .life-wheel__slice,.life-wheel__slice-link.is-active .life-wheel__slice{opacity:1;transform:scale(1.03);stroke-width:2.5}
+.life-wheel__slice-link:focus-visible .life-wheel__slice{stroke:#1f2937}
+.life-wheel__center{fill:#fff;stroke:rgba(148,163,184,.4);stroke-width:1.5}
+.life-wheel__center-text{font-family:"Inter",system-ui,-apple-system,"Segoe UI",sans-serif;font-size:18px;fill:#111827;font-weight:600;text-anchor:middle}
+.life-wheel__center-sub{font-family:"Inter",system-ui,-apple-system,"Segoe UI",sans-serif;font-size:13px;fill:#475569;text-anchor:middle;letter-spacing:.22em;text-transform:uppercase}
+.life-wheel__details{background:#fff;border-radius:22px;padding:30px;box-shadow:0 26px 55px rgba(15,23,42,.1);border:1px solid rgba(148,163,184,.25);max-width:420px;width:100%;transition:transform .3s ease,box-shadow .3s ease}
+.life-wheel__details h3{margin:0 0 12px;font-size:1.65rem;line-height:1.25}
+.life-wheel__details p{margin:0 0 22px;color:#4b5563;line-height:1.65;font-size:1rem}
+.life-wheel__details.is-active{transform:translateY(-4px);box-shadow:0 32px 66px rgba(15,23,42,.15)}
+.life-wheel__cta{display:inline-flex;align-items:center;gap:8px;padding:12px 20px;border-radius:999px;background:#eef2ff;color:#3730a3;font-weight:600;border:1px solid rgba(99,102,241,.22);transition:background .2s ease,transform .2s ease,text-decoration .2s ease}
+.life-wheel__cta::after{content:"→";font-size:1rem}
+.life-wheel__cta:hover{background:#e0e7ff;transform:translateY(-1px);text-decoration:none}
+
+.product-tags{display:flex;flex-wrap:wrap;gap:6px;margin-top:12px}
+.product-tags span{display:inline-flex;align-items:center;padding:4px 10px;border-radius:999px;background:#f1f5f9;color:#475569;font-size:.75rem;font-weight:600;letter-spacing:.01em}
+
+.products-empty{border:1px solid var(--border);border-radius:18px;padding:32px;text-align:center;background:#fff;box-shadow:0 18px 40px rgba(15,23,42,.08);max-width:560px;margin:24px auto}
+.products-empty p{margin:0 0 18px;color:#475569;font-size:1rem}
+.products-empty a{display:inline-flex;align-items:center;gap:6px;padding:10px 18px;border-radius:999px;background:#eef2ff;color:#1d4ed8;font-weight:600;text-decoration:none;border:1px solid rgba(37,99,235,.18)}
+.products-empty a::after{content:"→";font-size:.95rem}
+.products-empty a:hover{background:#dbeafe}
+
+@media(max-width:720px){
+  .life-wheel{padding:48px 18px}
+  .life-wheel__intro h2{font-size:30px}
+  .life-wheel__details{padding:24px}
+}
+
 .categories{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:12px;padding:20px;max-width:1100px;margin:0 auto 10px}
 .categories .cat{display:block;border:1px solid var(--border);border-radius:12px;padding:18px;background:#fff;box-shadow:var(--shadow);color:#111}
 .categories .cat h3{margin:0}


### PR DESCRIPTION
## Summary
- replace the homepage category cards with an interactive Life Harmony Wheel tied to eight life areas
- connect wheel slices to area-aware product listings with new filtering, tags, and empty states
- streamline the header navigation across pages to highlight Browse Life Harmony Apps/Tools alongside Bundles, FAQ / Support, and About

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cecd085150832d81e2c99234f5c277