### PR TITLE
Inline life wheel icons with SVG

### DIFF
--- a/app.js
+++ b/app.js
@@ -4,10 +4,127 @@
 
 const App = {};
 
+App.createIcon = function(content) {
+  return `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" aria-hidden="true" focusable="false">${content}</svg>`;
+};
+
+App.LIFE_ICONS = {
+  love: App.createIcon(`
+    <g
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.8"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <circle cx="9.5" cy="10" r="3.2" />
+      <circle cx="14.5" cy="10" r="3.2" />
+      <path d="M6.2 13.8c1.5 2.7 3.5 4.8 5.8 6.4 2.3 -1.6 4.3 -3.7 5.8 -6.4" />
+    </g>
+  `),
+  career: App.createIcon(`
+    <g
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.8"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <path d="M8 7V6a4 4 0 0 1 4-4 4 4 0 0 1 4 4v1" />
+      <rect x="4" y="7" width="16" height="12" rx="2.5" />
+      <path d="M4 12h16" />
+      <path d="M12 11.7v2.6" />
+    </g>
+  `),
+  health: App.createIcon(`
+    <g
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.8"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <circle cx="12" cy="12" r="7.5" />
+      <path d="M12 8.5v7" />
+      <path d="M8.5 12h7" />
+    </g>
+  `),
+  finances: App.createIcon(`
+    <g
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.8"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <ellipse cx="12" cy="8.5" rx="4.5" ry="2.5" />
+      <path d="M7.5 8.5v7c0 1.5 2 2.5 4.5 2.5s4.5 -1 4.5 -2.5v-7" />
+      <path d="M7.5 12c0 1.5 2 2.5 4.5 2.5s4.5 -1 4.5 -2.5" />
+    </g>
+  `),
+  fun: App.createIcon(`
+    <g
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.8"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <polygon points="12 4.5 14.1 9 19 9.6 15.6 12.7 16.7 17.4 12 14.9 7.3 17.4 8.4 12.7 5 9.6 9.9 9" />
+    </g>
+  `),
+  family: App.createIcon(`
+    <g
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.8"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <path d="M4.5 18c0-2.2 1.8-4 4-4h7c2.2 0 4 1.8 4 4" />
+      <circle cx="8.5" cy="10" r="3" />
+      <circle cx="15.5" cy="11.5" r="2.5" />
+    </g>
+  `),
+  environment: App.createIcon(`
+    <g
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.8"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <path d="M18.5 5.5c-6.7 -.8 -13 4.3 -13 10.4 0 1.9 1.4 3.5 3.2 3.7 2.1 .3 4.4 -1.4 6 -3.1l3.8 -4.1 -5.4 1.5 -3.6 3.2" />
+      <path d="M11 9.5c0 3 1.2 6 3.5 8.5" />
+    </g>
+  `),
+  spirituality: App.createIcon(`
+    <g
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.8"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+    >
+      <circle cx="12" cy="12" r="3.2" />
+      <path d="M12 5V3" />
+      <path d="M12 21v-2" />
+      <path d="M5 12H3" />
+      <path d="M21 12h-2" />
+      <path d="M6.8 6.8L5.4 5.4" />
+      <path d="M17.2 17.2L18.6 18.6" />
+      <path d="M6.8 17.2L5.4 18.6" />
+      <path d="M17.2 6.8L18.6 5.4" />
+    </g>
+  `)
+};
+
 App.LIFE_AREAS = {
   love: {
     title: "Love & Romantic Relationships",
     short: "Love",
+    color: "#F471B5",
+    icon: App.LIFE_ICONS.love,
     description: "Create rituals and check-ins that nurture meaningful partnerships.",
     link: "products.html?area=love",
     cta: "Explore relationship tools",
@@ -16,6 +133,8 @@ App.LIFE_AREAS = {
   career: {
     title: "Career, Growth & Learning",
     short: "Career",
+    color: "#A855F7",
+    icon: App.LIFE_ICONS.career,
     description: "Stay organized, track goals, and keep moving toward your next milestone.",
     link: "products.html?area=career",
     cta: "Stay on track with career tools",
@@ -24,6 +143,8 @@ App.LIFE_AREAS = {
   health: {
     title: "Health & Fitness",
     short: "Health",
+    color: "#22C55E",
+    icon: App.LIFE_ICONS.health,
     description: "Build calm routines for movement, rest, and mindful habits.",
     link: "products.html?area=health",
     cta: "See wellness templates",
@@ -32,6 +153,8 @@ App.LIFE_AREAS = {
   finances: {
     title: "Finances",
     short: "Finances",
+    color: "#FACC15",
+    icon: App.LIFE_ICONS.finances,
     description: "See your money clearly and plan budgets that match your values.",
     link: "products.html?area=finances",
     cta: "Review finance planners",
@@ -40,6 +163,8 @@ App.LIFE_AREAS = {
   fun: {
     title: "Fun & Recreation",
     short: "Fun",
+    color: "#FB923C",
+    icon: App.LIFE_ICONS.fun,
     description: "Plan adventures, hobbies, and creative breaks that refill your energy.",
     link: "products.html?area=fun",
     cta: "Find fun & recreation ideas",
@@ -48,6 +173,8 @@ App.LIFE_AREAS = {
   family: {
     title: "Family & Friends",
     short: "Family",
+    color: "#60A5FA",
+    icon: App.LIFE_ICONS.family,
     description: "Coordinate family schedules and stay connected with the people who matter most.",
     link: "products.html?area=family",
     cta: "Coordinate with family tools",
@@ -56,6 +183,8 @@ App.LIFE_AREAS = {
   environment: {
     title: "Physical Environment",
     short: "Environment",
+    color: "#14B8A6",
+    icon: App.LIFE_ICONS.environment,
     description: "Design supportive spaces, tidy routines, and home projects with clarity.",
     link: "products.html?area=environment",
     cta: "Design your ideal space",
@@ -64,6 +193,8 @@ App.LIFE_AREAS = {
   spirituality: {
     title: "Spirituality & Community",
     short: "Spirituality",
+    color: "#6366F1",
+    icon: App.LIFE_ICONS.spirituality,
     description: "Cultivate reflection, service, and community practices that ground you.",
     link: "products.html?area=spirituality",
     cta: "Discover community & reflection tools",
@@ -227,24 +358,103 @@ App.initHome = function() {
   const slices = App.qsa(".life-wheel__slice-link");
   if (!details || !slices.length) return;
 
+  const iconLayer = App.qs(".life-wheel__icons");
+
+  const hexToRgba = (hex, alpha = 1) => {
+    if (!hex) return "";
+    let value = hex.replace("#", "");
+    if (value.length === 3) {
+      value = value
+        .split("")
+        .map(ch => ch + ch)
+        .join("");
+    }
+    const int = parseInt(value, 16);
+    const r = (int >> 16) & 255;
+    const g = (int >> 8) & 255;
+    const b = int & 255;
+    return `rgba(${r}, ${g}, ${b}, ${alpha})`;
+  };
+
+  const iconLookup = new Map();
+
+  if (iconLayer) {
+    iconLayer.innerHTML = "";
+    slices.forEach((slice, index) => {
+      const area = slice.dataset.area;
+      const info = App.LIFE_AREAS[area];
+      if (!info) return;
+
+      const angle = -90 + index * 45;
+
+      const icon = document.createElement("div");
+      icon.className = "life-wheel__icon";
+      icon.dataset.area = area;
+      icon.style.setProperty("--angle", `${angle}deg`);
+      icon.style.setProperty("--angle-inverse", `${-angle}deg`);
+      icon.style.setProperty("--area-color", info.color);
+      icon.style.setProperty("--area-glow", hexToRgba(info.color, 0.34));
+
+      const inner = document.createElement("span");
+      inner.className = "life-wheel__icon-inner";
+      inner.innerHTML = info.icon || "";
+
+      icon.appendChild(inner);
+      iconLayer.appendChild(icon);
+      iconLookup.set(area, icon);
+    });
+  } else {
+    App.qsa(".life-wheel__icon").forEach(icon => {
+      if (icon.dataset.area) iconLookup.set(icon.dataset.area, icon);
+    });
+  }
+
   const defaultState = {
     title: details.dataset.defaultTitle || "Explore the Life Harmony Wheel",
     description: details.dataset.defaultDescription || "",
     link: details.dataset.defaultLink || "products.html",
-    cta: details.dataset.defaultCta || "Browse all Life Harmony tools"
+    cta: details.dataset.defaultCta || "Browse all Life Harmony tools",
+    icon: null,
+    color: null,
+    area: null
+  };
+
+  const setAccent = color => {
+    if (color) {
+      details.style.setProperty("--detail-color", color);
+      details.style.setProperty("--detail-glow", hexToRgba(color, 0.24));
+      details.style.setProperty("--detail-sheen", hexToRgba(color, 0.14));
+    } else {
+      details.style.removeProperty("--detail-color");
+      details.style.removeProperty("--detail-glow");
+      details.style.removeProperty("--detail-sheen");
+    }
   };
 
   const render = (state, isActive = false) => {
-    const { title, description, link, cta } = state;
+    const { title, description, link, cta, icon, area } = state;
+    const iconMarkup = icon
+      ? `<span class="life-wheel__detail-icon" aria-hidden="true">${icon}</span>`
+      : "";
     details.innerHTML = `
-      <h3>${title}</h3>
-      <p>${description}</p>
-      <a class="life-wheel__cta" href="${link}">${cta}</a>
+      ${iconMarkup}
+      <div class="life-wheel__detail-copy">
+        <h3>${title}</h3>
+        <p>${description}</p>
+        <a class="life-wheel__cta" href="${link}">${cta}</a>
+      </div>
     `;
+    if (area) {
+      details.dataset.area = area;
+    } else {
+      details.removeAttribute("data-area");
+    }
+    details.classList.toggle("has-icon", Boolean(icon));
     details.classList.toggle("is-active", isActive);
   };
 
   let activeSlice = null;
+  let activeIcon = null;
   let resetTimer = null;
 
   const setActive = slice => {
@@ -255,9 +465,18 @@ App.initHome = function() {
     if (activeSlice && activeSlice !== slice) {
       activeSlice.classList.remove("is-active");
     }
+    const iconEl = iconLookup.get(area);
+    if (activeIcon && activeIcon !== iconEl) {
+      activeIcon.classList.remove("is-active");
+    }
+    if (iconEl) {
+      iconEl.classList.add("is-active");
+    }
     activeSlice = slice;
+    activeIcon = iconEl || null;
     slice.classList.add("is-active");
-    render(info, true);
+    setAccent(info.color);
+    render({ ...info, area }, true);
   };
 
   const reset = () => {
@@ -266,6 +485,11 @@ App.initHome = function() {
       activeSlice.classList.remove("is-active");
       activeSlice = null;
     }
+    if (activeIcon) {
+      activeIcon.classList.remove("is-active");
+      activeIcon = null;
+    }
+    setAccent(null);
     render(defaultState, false);
   };
 

--- a/index.html
+++ b/index.html
@@ -82,15 +82,18 @@
           <text class="life-wheel__center-text" x="180" y="194">Harmony</text>
           <text class="life-wheel__center-sub" x="180" y="222">Wheel</text>
         </svg>
+        <div class="life-wheel__icons" aria-hidden="true"></div>
       </div>
       <div class="life-wheel__details" id="life-wheel-details"
            data-default-title="Explore the Life Harmony Wheel"
            data-default-description="Hover over a slice to discover the tools we recommend for each area of your life."
            data-default-link="products.html"
            data-default-cta="Browse all Life Harmony tools">
-        <h3>Explore the Life Harmony Wheel</h3>
-        <p>Hover over a slice to discover the tools we recommend for each area of your life.</p>
-        <a class="life-wheel__cta" href="products.html">Browse all Life Harmony tools</a>
+        <div class="life-wheel__detail-copy">
+          <h3>Explore the Life Harmony Wheel</h3>
+          <p>Hover over a slice to discover the tools we recommend for each area of your life.</p>
+          <a class="life-wheel__cta" href="products.html">Browse all Life Harmony tools</a>
+        </div>
       </div>
     </div>
   </section>

--- a/style.css
+++ b/style.css
@@ -49,8 +49,13 @@ img{max-width:100%;display:block}
 .life-wheel__intro h2{margin:0 0 14px;font-size:36px;line-height:1.2}
 .life-wheel__intro p{margin:0;color:#4b5563;font-size:1.05rem}
 .life-wheel__layout{display:grid;gap:36px;align-items:center;justify-items:center;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));max-width:1100px;margin:0 auto}
-.life-wheel__graphic{width:min(420px,100%);filter:drop-shadow(0 24px 45px rgba(79,114,205,.18))}
+.life-wheel__graphic{position:relative;width:min(420px,100%);filter:drop-shadow(0 24px 45px rgba(79,114,205,.18))}
 .life-wheel__graphic svg{width:100%;height:auto;display:block}
+.life-wheel__icons{position:absolute;inset:0;pointer-events:none}
+.life-wheel__icon{position:absolute;top:50%;left:50%;width:0;height:0;transform:rotate(var(--angle));transition:opacity .3s ease}
+.life-wheel__icon-inner{--icon-offset:calc(min(420px,100%)*.44 - 32px);--icon-transform:translate(-50%,calc(-1 * var(--icon-offset))) rotate(var(--angle-inverse));width:64px;height:64px;border-radius:20px;background:var(--area-color);color:#fff;display:flex;align-items:center;justify-content:center;box-shadow:0 16px 32px var(--area-glow);transform:var(--icon-transform) scale(.9);transition:transform .3s ease,box-shadow .3s ease,opacity .3s ease;opacity:.82}
+.life-wheel__icon svg{width:36px;height:36px;display:block}
+.life-wheel__icon.is-active .life-wheel__icon-inner{transform:var(--icon-transform) scale(1);opacity:1;box-shadow:0 22px 42px var(--area-glow)}
 .life-wheel__slice{cursor:pointer;transition:transform .3s ease,opacity .3s ease,stroke-width .3s ease;transform-origin:180px 180px;transform-box:fill-box;opacity:.92;stroke:rgba(255,255,255,.9);stroke-width:1.5}
 .life-wheel__slice-link{outline:none}
 .life-wheel__slice-link:hover .life-wheel__slice,.life-wheel__slice-link:focus .life-wheel__slice,.life-wheel__slice-link.is-active .life-wheel__slice{opacity:1;transform:scale(1.03);stroke-width:2.5}
@@ -58,10 +63,16 @@ img{max-width:100%;display:block}
 .life-wheel__center{fill:#fff;stroke:rgba(148,163,184,.4);stroke-width:1.5}
 .life-wheel__center-text{font-family:"Inter",system-ui,-apple-system,"Segoe UI",sans-serif;font-size:18px;fill:#111827;font-weight:600;text-anchor:middle}
 .life-wheel__center-sub{font-family:"Inter",system-ui,-apple-system,"Segoe UI",sans-serif;font-size:13px;fill:#475569;text-anchor:middle;letter-spacing:.22em;text-transform:uppercase}
-.life-wheel__details{background:#fff;border-radius:22px;padding:30px;box-shadow:0 26px 55px rgba(15,23,42,.1);border:1px solid rgba(148,163,184,.25);max-width:420px;width:100%;transition:transform .3s ease,box-shadow .3s ease}
-.life-wheel__details h3{margin:0 0 12px;font-size:1.65rem;line-height:1.25}
-.life-wheel__details p{margin:0 0 22px;color:#4b5563;line-height:1.65;font-size:1rem}
-.life-wheel__details.is-active{transform:translateY(-4px);box-shadow:0 32px 66px rgba(15,23,42,.15)}
+.life-wheel__details{--detail-color:#6366f1;--detail-glow:rgba(99,102,241,.18);--detail-sheen:transparent;background:#fff;border-radius:22px;padding:30px;box-shadow:0 26px 55px rgba(15,23,42,.1);border:2px solid rgba(148,163,184,.25);max-width:420px;width:100%;transition:transform .3s ease,box-shadow .3s ease,border-color .3s ease;display:grid;gap:20px;grid-template-columns:1fr;align-items:start;background-clip:padding-box}
+.life-wheel__details.has-icon{grid-template-columns:auto 1fr;gap:24px}
+.life-wheel__details h3{margin:0;font-size:1.65rem;line-height:1.25}
+.life-wheel__details p{margin:0;color:#4b5563;line-height:1.65;font-size:1rem}
+.life-wheel__details.is-active{transform:translateY(-4px);box-shadow:0 32px 66px rgba(15,23,42,.15),0 0 0 6px var(--detail-sheen);border-color:var(--detail-color)}
+.life-wheel__detail-icon{width:64px;height:64px;border-radius:20px;background:var(--detail-color);color:#fff;display:flex;align-items:center;justify-content:center;box-shadow:0 18px 36px var(--detail-glow);transition:transform .3s ease,box-shadow .3s ease}
+.life-wheel__details.is-active .life-wheel__detail-icon{transform:translateY(-2px);box-shadow:0 22px 44px var(--detail-glow)}
+.life-wheel__detail-icon svg{width:36px;height:36px;display:block}
+.life-wheel__detail-copy{display:grid;gap:18px;min-width:0}
+.life-wheel__detail-copy .life-wheel__cta{justify-self:start}
 .life-wheel__cta{display:inline-flex;align-items:center;gap:8px;padding:12px 20px;border-radius:999px;background:#eef2ff;color:#3730a3;font-weight:600;border:1px solid rgba(99,102,241,.22);transition:background .2s ease,transform .2s ease,text-decoration .2s ease}
 .life-wheel__cta::after{content:"→";font-size:1rem}
 .life-wheel__cta:hover{background:#e0e7ff;transform:translateY(-1px);text-decoration:none}
@@ -79,6 +90,10 @@ img{max-width:100%;display:block}
   .life-wheel{padding:48px 18px}
   .life-wheel__intro h2{font-size:30px}
   .life-wheel__details{padding:24px}
+  .life-wheel__details.has-icon{grid-template-columns:1fr;gap:20px;justify-items:start}
+  .life-wheel__detail-icon{width:56px;height:56px;border-radius:18px;justify-self:start}
+  .life-wheel__icon-inner{width:56px;height:56px;border-radius:18px;--icon-offset:calc(min(420px,100%)*.44 - 28px)}
+  .life-wheel__icon svg,.life-wheel__detail-icon svg{width:30px;height:30px}
 }
 
 @media(max-width:720px){


### PR DESCRIPTION
## Summary
- define reusable inline SVG markup for each Life Harmony wheel area and reference it from the LIFE_AREAS data instead of PNG assets
- update the home page wheel logic to inject the SVG markup for slice overlays and the details card accent icon while keeping the accent state handling intact
- refresh the life wheel styling so the inline SVG icons inherit the slice color, size correctly, and remain responsive on smaller screens

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cf230fc9a0832d887f74a888f59686