### PR TITLE
Fix life wheel icon rendering

### DIFF
--- a/app.js
+++ b/app.js
@@ -393,24 +393,12 @@ App.initHome = function() {
       const info = App.LIFE_AREAS[area];
       if (!info) return;
 
-
       const icon = document.createElement("div");
       icon.className = "life-wheel__icon";
       icon.dataset.area = area;
-      icon.style.setProperty("--area-color", info.color);
-      icon.style.setProperty("--area-glow", hexToRgba(info.color, 0.34));
       icon.dataset.index = String(index);
-
-      const angle = -90 + index * 45;
-
-      const icon = document.createElement("div");
-      icon.className = "life-wheel__icon";
-      icon.dataset.area = area;
-      icon.style.setProperty("--angle", `${angle}deg`);
-      icon.style.setProperty("--angle-inverse", `${-angle}deg`);
       icon.style.setProperty("--area-color", info.color);
       icon.style.setProperty("--area-glow", hexToRgba(info.color, 0.34));
-
 
       const inner = document.createElement("span");
       inner.className = "life-wheel__icon-inner";
@@ -418,18 +406,26 @@ App.initHome = function() {
 
       icon.appendChild(inner);
       iconLayer.appendChild(icon);
-      iconLookup.set(area, icon);
 
+      iconLookup.set(area, icon);
       iconData.push({ icon, index });
     });
   } else {
     App.qsa(".life-wheel__icon").forEach(icon => {
       const area = icon.dataset.area;
       if (!area) return;
-      const index = sliceIndices.has(area) ? sliceIndices.get(area) : 0;
-      icon.dataset.index = String(index ?? 0);
+      const info = App.LIFE_AREAS[area];
+      let index = sliceIndices.has(area)
+        ? sliceIndices.get(area)
+        : parseInt(icon.dataset.index || "0", 10);
+      if (!Number.isFinite(index)) index = 0;
+      if (info) {
+        icon.style.setProperty("--area-color", info.color);
+        icon.style.setProperty("--area-glow", hexToRgba(info.color, 0.34));
+      }
+      icon.dataset.index = String(index);
       iconLookup.set(area, icon);
-      iconData.push({ icon, index: index ?? 0 });
+      iconData.push({ icon, index });
     });
   }
 
@@ -467,14 +463,6 @@ App.initHome = function() {
   };
 
   window.addEventListener("resize", handleResize);
-
-
-    });
-  } else {
-    App.qsa(".life-wheel__icon").forEach(icon => {
-      if (icon.dataset.area) iconLookup.set(icon.dataset.area, icon);
-    });
-  }
 
 
   const defaultState = {

--- a/style.css
+++ b/style.css
@@ -58,11 +58,6 @@ img{max-width:100%;display:block}
 .life-wheel__icon svg{width:calc(var(--icon-size,64px)*.56);height:calc(var(--icon-size,64px)*.56);display:block}
 .life-wheel__icon.is-active .life-wheel__icon-inner{transform:scale(1);opacity:1;box-shadow:0 22px 42px var(--area-glow)}
 
-.life-wheel__icon{position:absolute;top:50%;left:50%;width:0;height:0;transform:rotate(var(--angle));transition:opacity .3s ease}
-.life-wheel__icon-inner{--icon-offset:calc(min(420px,100%)*.44 - 32px);--icon-transform:translate(-50%,calc(-1 * var(--icon-offset))) rotate(var(--angle-inverse));width:64px;height:64px;border-radius:20px;background:var(--area-color);color:#fff;display:flex;align-items:center;justify-content:center;box-shadow:0 16px 32px var(--area-glow);transform:var(--icon-transform) scale(.9);transition:transform .3s ease,box-shadow .3s ease,opacity .3s ease;opacity:.82}
-.life-wheel__icon svg{width:36px;height:36px;display:block}
-.life-wheel__icon.is-active .life-wheel__icon-inner{transform:var(--icon-transform) scale(1);opacity:1;box-shadow:0 22px 42px var(--area-glow)}
-
 .life-wheel__slice{cursor:pointer;transition:transform .3s ease,opacity .3s ease,stroke-width .3s ease;transform-origin:180px 180px;transform-box:fill-box;opacity:.92;stroke:rgba(255,255,255,.9);stroke-width:1.5}
 .life-wheel__slice-link{outline:none}
 .life-wheel__slice-link:hover .life-wheel__slice,.life-wheel__slice-link:focus .life-wheel__slice,.life-wheel__slice-link.is-active .life-wheel__slice{opacity:1;transform:scale(1.03);stroke-width:2.5}
@@ -98,12 +93,8 @@ img{max-width:100%;display:block}
   .life-wheel__intro h2{font-size:30px}
   .life-wheel__details{padding:24px}
   .life-wheel__details.has-icon{grid-template-columns:1fr;gap:20px;justify-items:start}
-  .life-wheel__detail-icon{width:56px;height:56px;border-radius:18px;justify-self:start}
-
-  .life-wheel__detail-icon svg{width:30px;height:30px}
-
-  .life-wheel__icon-inner{width:56px;height:56px;border-radius:18px;--icon-offset:calc(min(420px,100%)*.44 - 28px)}
-  .life-wheel__icon svg,.life-wheel__detail-icon svg{width:30px;height:30px}
+    .life-wheel__detail-icon{width:56px;height:56px;border-radius:18px;justify-self:start}
+    .life-wheel__detail-icon svg{width:30px;height:30px}
 
 }
 


### PR DESCRIPTION
## Summary
- rebuild the life wheel icon injection logic so each slice renders the matching SVG and keeps its styling metadata
- position icons relative to the wheel geometry and recalc on resize events
- remove conflicting CSS so the overlayed icons stay visible inside their wedges

## Testing
- node -e "new Function(require('fs').readFileSync('app.js','utf8'))"


------
https://chatgpt.com/codex/tasks/task_e_68cfc849777c832d9847185ff65f6ec1