### PR TITLE
Add desktop slice labels and improve mobile life wheel interaction

### DIFF
--- a/style.css
+++ b/style.css
@@ -52,6 +52,11 @@ img{max-width:100%;display:block}
 .life-wheel__graphic{position:relative;width:min(420px,100%);filter:drop-shadow(0 24px 45px rgba(79,114,205,.18))}
 .life-wheel__graphic svg{width:100%;height:auto;display:block}
 .life-wheel__icons{position:absolute;inset:0;pointer-events:none}
+.life-wheel__labels{position:absolute;inset:0;pointer-events:none;z-index:3}
+.life-wheel__label{position:absolute;top:var(--label-y,50%);left:var(--label-x,50%);transform:translate(-50%,-50%);font-size:var(--label-font-size,.95rem);font-weight:600;letter-spacing:.01em;color:rgba(30,41,59,.7);background:rgba(255,255,255,.78);border-radius:999px;padding:6px 14px;border:1px solid rgba(148,163,184,.32);box-shadow:0 18px 36px rgba(15,23,42,.08);text-align:center;max-width:150px;line-height:1.3;transition:color .3s ease,border-color .3s ease,box-shadow .3s ease,background .3s ease,opacity .3s ease,transform .3s ease;opacity:.82}
+.life-wheel__label[data-align="left"]{text-align:right}
+.life-wheel__label[data-align="right"]{text-align:left}
+.life-wheel__label.is-active{color:var(--area-color,#1d4ed8);border-color:var(--area-color,#6366f1);background:#fff;box-shadow:0 24px 46px var(--area-glow,rgba(99,102,241,.18));opacity:1;transform:translate(-50%,-50%) scale(1.02)}
 
 .life-wheel__icon{position:absolute;top:var(--icon-y,50%);left:var(--icon-x,50%);width:var(--icon-size,64px);height:var(--icon-size,64px);transform:translate(-50%,-50%);transition:opacity .3s ease}
 .life-wheel__icon-inner{width:100%;height:100%;border-radius:calc(var(--icon-size,64px)*.32);background:var(--area-color);color:#fff;display:flex;align-items:center;justify-content:center;box-shadow:0 16px 32px var(--area-glow);transform:scale(.88);transition:transform .3s ease,box-shadow .3s ease,opacity .3s ease;opacity:.82}
@@ -95,6 +100,7 @@ img{max-width:100%;display:block}
   .life-wheel__details.has-icon{grid-template-columns:1fr;gap:20px;justify-items:start}
     .life-wheel__detail-icon{width:56px;height:56px;border-radius:18px;justify-self:start}
     .life-wheel__detail-icon svg{width:30px;height:30px}
+  .life-wheel__labels{display:none}
 
 }
 


### PR DESCRIPTION
## Summary
- render labeled captions around the Life Harmony Wheel slices on large screens and highlight them with the matching slice color when active
- position the new labels responsively beside each slice and hide them on mobile for a clean layout
- on small screens, automatically scroll the wheel and detail card into view after the first tap for better visibility

## Testing
- no automated tests were run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68cfcec873c0832da0b25937ae458e79