### PR TITLE
Add mega menu navigation and refresh header styling

### DIFF
--- a/about.html
+++ b/about.html
@@ -9,16 +9,23 @@
 </head>
 <body class="theme-neutral">
 <header class="site-header">
-  <a class="brand" href="/"><img src="assets/logo.svg" alt=""><span>Harmony Sheets</span></a>
+  <a class="brand" href="/">Harmony Sheets</a>
   <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">
     <span class="sr-only">Toggle navigation</span>
     <span class="nav-toggle__icon" aria-hidden="true"></span>
   </button>
   <nav class="main-nav" id="site-menu">
-    <a href="products.html">Browse Life Harmony Apps/Tools</a>
-    <a href="bundles.html">Bundles</a>
-    <a href="faq.html">FAQ / Support</a>
-    <a href="about.html">About</a>
+    <div class="nav-item nav-item--browse">
+      <a class="nav-link nav-link--browse" href="products.html" aria-haspopup="true" aria-expanded="false">Browse Life Harmony Apps/Tools</a>
+      <div class="nav-mega" role="menu" aria-label="Life Harmony categories">
+        <div class="nav-mega__content" data-nav-mega-content>
+          <p class="nav-mega__placeholder">Loading Life Harmony areas…</p>
+        </div>
+      </div>
+    </div>
+    <a class="nav-link" href="bundles.html">Bundles</a>
+    <a class="nav-link" href="faq.html">FAQ / Support</a>
+    <a class="nav-link" href="about.html">About</a>
   </nav>
 </header>
 

--- a/bundles.html
+++ b/bundles.html
@@ -9,16 +9,23 @@
 </head>
 <body class="theme-neutral">
 <header class="site-header">
-  <a class="brand" href="/"><img src="assets/logo.svg" alt=""><span>Harmony Sheets</span></a>
+  <a class="brand" href="/">Harmony Sheets</a>
   <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">
     <span class="sr-only">Toggle navigation</span>
     <span class="nav-toggle__icon" aria-hidden="true"></span>
   </button>
   <nav class="main-nav" id="site-menu">
-    <a href="products.html">Browse Life Harmony Apps/Tools</a>
-    <a href="bundles.html">Bundles</a>
-    <a href="faq.html">FAQ / Support</a>
-    <a href="about.html">About</a>
+    <div class="nav-item nav-item--browse">
+      <a class="nav-link nav-link--browse" href="products.html" aria-haspopup="true" aria-expanded="false">Browse Life Harmony Apps/Tools</a>
+      <div class="nav-mega" role="menu" aria-label="Life Harmony categories">
+        <div class="nav-mega__content" data-nav-mega-content>
+          <p class="nav-mega__placeholder">Loading Life Harmony areas…</p>
+        </div>
+      </div>
+    </div>
+    <a class="nav-link" href="bundles.html">Bundles</a>
+    <a class="nav-link" href="faq.html">FAQ / Support</a>
+    <a class="nav-link" href="about.html">About</a>
   </nav>
 </header>
 

--- a/faq.html
+++ b/faq.html
@@ -9,16 +9,23 @@
 </head>
 <body class="theme-neutral">
 <header class="site-header">
-  <a class="brand" href="/"><img src="assets/logo.svg" alt=""><span>Harmony Sheets</span></a>
+  <a class="brand" href="/">Harmony Sheets</a>
   <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">
     <span class="sr-only">Toggle navigation</span>
     <span class="nav-toggle__icon" aria-hidden="true"></span>
   </button>
   <nav class="main-nav" id="site-menu">
-    <a href="products.html">Browse Life Harmony Apps/Tools</a>
-    <a href="bundles.html">Bundles</a>
-    <a href="faq.html">FAQ / Support</a>
-    <a href="about.html">About</a>
+    <div class="nav-item nav-item--browse">
+      <a class="nav-link nav-link--browse" href="products.html" aria-haspopup="true" aria-expanded="false">Browse Life Harmony Apps/Tools</a>
+      <div class="nav-mega" role="menu" aria-label="Life Harmony categories">
+        <div class="nav-mega__content" data-nav-mega-content>
+          <p class="nav-mega__placeholder">Loading Life Harmony areas…</p>
+        </div>
+      </div>
+    </div>
+    <a class="nav-link" href="bundles.html">Bundles</a>
+    <a class="nav-link" href="faq.html">FAQ / Support</a>
+    <a class="nav-link" href="about.html">About</a>
   </nav>
 </header>
 

--- a/index.html
+++ b/index.html
@@ -10,16 +10,23 @@
 </head>
 <body class="theme-neutral">
 <header class="site-header">
-  <a class="brand" href="/"><img src="assets/logo.svg" alt=""><span>Harmony Sheets</span></a>
+  <a class="brand" href="/">Harmony Sheets</a>
   <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">
     <span class="sr-only">Toggle navigation</span>
     <span class="nav-toggle__icon" aria-hidden="true"></span>
   </button>
   <nav class="main-nav" id="site-menu">
-    <a href="products.html">Browse Life Harmony Apps/Tools</a>
-    <a href="bundles.html">Bundles</a>
-    <a href="faq.html">FAQ / Support</a>
-    <a href="about.html">About</a>
+    <div class="nav-item nav-item--browse">
+      <a class="nav-link nav-link--browse" href="products.html" aria-haspopup="true" aria-expanded="false">Browse Life Harmony Apps/Tools</a>
+      <div class="nav-mega" role="menu" aria-label="Life Harmony categories">
+        <div class="nav-mega__content" data-nav-mega-content>
+          <p class="nav-mega__placeholder">Loading Life Harmony areas…</p>
+        </div>
+      </div>
+    </div>
+    <a class="nav-link" href="bundles.html">Bundles</a>
+    <a class="nav-link" href="faq.html">FAQ / Support</a>
+    <a class="nav-link" href="about.html">About</a>
   </nav>
 </header>
 

--- a/product.html
+++ b/product.html
@@ -10,16 +10,23 @@
 
 <body class="page-product">
   <header class="site-header">
-    <a class="brand" href="/"><img src="assets/logo.svg" alt=""><span>Harmony Sheets</span></a>
+    <a class="brand" href="/">Harmony Sheets</a>
     <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">
       <span class="sr-only">Toggle navigation</span>
       <span class="nav-toggle__icon" aria-hidden="true"></span>
     </button>
     <nav class="main-nav" id="site-menu">
-      <a href="products.html">Browse Life Harmony Apps/Tools</a>
-      <a href="bundles.html">Bundles</a>
-      <a href="faq.html">FAQ / Support</a>
-      <a href="about.html">About</a>
+      <div class="nav-item nav-item--browse">
+        <a class="nav-link nav-link--browse" href="products.html" aria-haspopup="true" aria-expanded="false">Browse Life Harmony Apps/Tools</a>
+        <div class="nav-mega" role="menu" aria-label="Life Harmony categories">
+          <div class="nav-mega__content" data-nav-mega-content>
+            <p class="nav-mega__placeholder">Loading Life Harmony areas…</p>
+          </div>
+        </div>
+      </div>
+      <a class="nav-link" href="bundles.html">Bundles</a>
+      <a class="nav-link" href="faq.html">FAQ / Support</a>
+      <a class="nav-link" href="about.html">About</a>
     </nav>
   </header>
 

--- a/products.html
+++ b/products.html
@@ -9,16 +9,23 @@
 </head>
 <body class="page-products">
   <header class="site-header">
-    <a class="brand" href="/"><img src="assets/logo.svg" alt=""><span>Harmony Sheets</span></a>
+    <a class="brand" href="/">Harmony Sheets</a>
     <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">
       <span class="sr-only">Toggle navigation</span>
       <span class="nav-toggle__icon" aria-hidden="true"></span>
     </button>
     <nav class="main-nav" id="site-menu">
-      <a href="products.html">Browse Life Harmony Apps/Tools</a>
-      <a href="bundles.html">Bundles</a>
-      <a href="faq.html">FAQ / Support</a>
-      <a href="about.html">About</a>
+      <div class="nav-item nav-item--browse">
+        <a class="nav-link nav-link--browse" href="products.html" aria-haspopup="true" aria-expanded="false">Browse Life Harmony Apps/Tools</a>
+        <div class="nav-mega" role="menu" aria-label="Life Harmony categories">
+          <div class="nav-mega__content" data-nav-mega-content>
+            <p class="nav-mega__placeholder">Loading Life Harmony areas…</p>
+          </div>
+        </div>
+      </div>
+      <a class="nav-link" href="bundles.html">Bundles</a>
+      <a class="nav-link" href="faq.html">FAQ / Support</a>
+      <a class="nav-link" href="about.html">About</a>
     </nav>
   </header>
 

--- a/style.css
+++ b/style.css
@@ -16,13 +16,34 @@ body{margin:0;background:var(--bg);color:var(--text);font:16px/1.5 system-ui,-ap
 a{color:var(--brand);text-decoration:none}
 img{max-width:100%;display:block}
 
-.site-header{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:14px 20px;border-bottom:1px solid var(--border);position:sticky;top:0;background:#fff;z-index:50}
-.brand{display:flex;gap:10px;align-items:center;font-weight:700;color:inherit}
-.brand img{height:28px}
-.main-nav{display:flex;align-items:center;gap:18px}
-.main-nav a{color:#111;opacity:.85;font-weight:500;padding:8px 0;transition:opacity .2s ease,color .2s ease}
-.main-nav a:hover,.main-nav a:focus-visible{opacity:1}
-.main-nav a.active{color:var(--brand);opacity:1}
+.site-header{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:14px 20px;border-bottom:1px solid var(--border);position:sticky;top:0;background:rgba(255,255,255,.96);backdrop-filter:saturate(150%) blur(14px);z-index:60}
+.brand{display:inline-flex;align-items:center;gap:8px;font-weight:700;font-size:1.12rem;letter-spacing:.02em;color:#0f172a;text-decoration:none;transition:color .2s ease}
+.brand:hover,.brand:focus-visible{color:#1d4ed8}
+.main-nav{display:flex;align-items:center;gap:10px;padding:6px 8px;border-radius:999px;background:rgba(244,246,255,.72);border:1px solid rgba(148,163,184,.24);box-shadow:0 12px 30px rgba(15,23,42,.08);position:relative}
+.nav-item{position:relative}
+.nav-link{display:inline-flex;align-items:center;gap:8px;padding:10px 14px;border-radius:12px;font-weight:600;color:#1f2937;background:transparent;transition:background .2s ease,color .2s ease,box-shadow .2s ease}
+.nav-link:hover,.nav-link:focus-visible{background:rgba(255,255,255,.95);box-shadow:0 10px 20px rgba(15,23,42,.08);color:#0f172a}
+.nav-link.active{background:#1d4ed8;color:#fff;box-shadow:0 12px 26px rgba(37,99,235,.26)}
+.nav-link--browse::after{content:"▾";font-size:.68em;margin-left:6px;transition:transform .2s ease}
+.nav-item--browse.is-open>.nav-link--browse::after,.nav-item--browse:hover>.nav-link--browse::after{transform:rotate(180deg)}
+.nav-item--browse .nav-mega{position:absolute;top:calc(100% + 14px);left:0;width:min(760px,calc(100vw - 40px));background:rgba(255,255,255,.98);border-radius:22px;border:1px solid rgba(148,163,184,.26);box-shadow:0 32px 68px rgba(15,23,42,.18);padding:24px;opacity:0;transform:translateY(10px);pointer-events:none;visibility:hidden;transition:opacity .2s ease,transform .2s ease,visibility .2s ease;z-index:70}
+.nav-item--browse:hover .nav-mega,.nav-item--browse:focus-within .nav-mega,.nav-item--browse.is-open .nav-mega{opacity:1;transform:translateY(0);pointer-events:auto;visibility:visible}
+.nav-mega__content{display:grid;gap:18px}
+.nav-mega__grid{display:grid;gap:18px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+.nav-mega__group{border-radius:18px;padding:18px;background:linear-gradient(150deg,var(--area-soft,#eef2ff) 0%,#fff 100%);border:1px solid var(--area-border,rgba(148,163,184,.2));box-shadow:0 18px 36px rgba(15,23,42,.08);display:flex;flex-direction:column;gap:12px;min-height:190px}
+.nav-mega__heading{display:flex;align-items:center;justify-content:space-between;gap:8px;flex-wrap:wrap}
+.nav-mega__badge{display:inline-flex;align-items:center;gap:4px;padding:4px 10px;border-radius:999px;background:var(--area-color,#6366f1);color:#fff;font-size:.75rem;font-weight:600;box-shadow:0 8px 18px var(--area-border,rgba(99,102,241,.2))}
+.nav-mega__label{font-size:1rem;font-weight:600;color:#0f172a}
+.nav-mega__products{list-style:none;margin:0;padding:0;display:grid;gap:6px}
+.nav-mega__products a{display:flex;align-items:center;gap:6px;padding:7px 12px;border-radius:10px;background:rgba(255,255,255,.9);border:1px solid rgba(148,163,184,.22);color:#1f2937;font-size:.92rem;font-weight:500;transition:border-color .2s ease,background .2s ease,color .2s ease,transform .2s ease}
+.nav-mega__products a::before{content:"•";color:var(--area-ink,var(--area-color,#6366f1));font-size:.8rem;transform:translateY(-1px)}
+.nav-mega__products a:hover,.nav-mega__products a:focus-visible{background:var(--area-soft,#eef2ff);border-color:var(--area-color,#6366f1);color:var(--area-color,#6366f1);transform:translateY(-1px)}
+.nav-mega__empty{color:#64748b;font-size:.9rem;padding:6px 0}
+.nav-mega__area-link{margin-top:auto;align-self:flex-start;font-weight:600;font-size:.92rem;color:var(--area-color,#4338ca);display:inline-flex;align-items:center;gap:6px}
+.nav-mega__area-link::after{content:"→"}
+.nav-mega__placeholder{margin:0;color:#475569}
+.nav-mega__footer{display:flex;justify-content:flex-end;padding-top:12px;border-top:1px solid rgba(148,163,184,.2)}
+.nav-mega__footer a{font-weight:600;color:#1d4ed8}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
 .nav-toggle{display:none;align-items:center;justify-content:center;border:1px solid var(--border);background:#fff;border-radius:10px;width:44px;height:44px;padding:0;cursor:pointer;transition:box-shadow .2s ease,border-color .2s ease}
 .nav-toggle:hover{border-color:#cbd5ff;box-shadow:0 10px 24px rgba(79,114,205,.18)}
@@ -107,12 +128,19 @@ img{max-width:100%;display:block}
 @media(max-width:720px){
   .site-header{flex-wrap:wrap;padding:14px 16px}
   .nav-toggle{display:inline-flex;margin-left:auto}
-  .main-nav{display:none;width:100%;flex-direction:column;align-items:flex-start;gap:8px;margin-top:12px;padding:14px;border:1px solid var(--border);border-radius:14px;background:#fff;box-shadow:0 18px 40px rgba(15,23,42,.08)}
+  .main-nav{display:none;width:100%;flex-direction:column;align-items:stretch;gap:10px;margin-top:12px;padding:14px;border:1px solid var(--border);border-radius:14px;background:#fff;box-shadow:0 18px 40px rgba(15,23,42,.08)}
   .main-nav.is-open{display:flex}
-  .main-nav a{width:100%;margin:0;padding:10px 12px;border-radius:8px;background:#f3f4ff;border:1px solid transparent;transition:background .2s ease,border-color .2s ease}
-  .main-nav a + a{margin-top:4px}
-  .main-nav a:hover,.main-nav a:focus-visible{background:#e0e7ff}
-  .main-nav a.active{background:#dbeafe;color:#1d4ed8}
+  .main-nav>*+*{margin-top:6px}
+  .nav-item{width:100%}
+  .nav-link{width:100%;justify-content:space-between;background:#f8f9ff;border:1px solid transparent;box-shadow:none}
+  .nav-link:hover,.nav-link:focus-visible{background:#e0e7ff;box-shadow:none}
+  .nav-link.active{background:#dbeafe;color:#1d4ed8}
+  .nav-item--browse .nav-link--browse::after{transform:none}
+  .nav-item--browse .nav-mega{position:static;width:100%;margin-top:10px;padding:16px;border-radius:16px;border:1px solid rgba(148,163,184,.26);box-shadow:none;opacity:1;transform:none;visibility:visible;pointer-events:auto;display:none;background:#f8faff}
+  .nav-item--browse.is-open .nav-mega{display:block}
+  .nav-mega__grid{grid-template-columns:1fr}
+  .nav-mega__group{min-height:auto}
+  .nav-mega__footer{justify-content:flex-start}
 }
 
 .categories{display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:12px;padding:20px;max-width:1100px;margin:0 auto 10px}


### PR DESCRIPTION
## Summary
- replace the duplicate logo markup with a text brand link and add a mega-menu wrapper around the browse navigation item on every page
- restyle the header navigation to pill-like buttons and add desktop/mobile mega-menu layouts with color-accented category cards
- load product data once, build the hover dropdown with category/product listings, and nudge life-wheel labels outward for better spacing

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cfd37c0194832d9d443773abd74ab1