### PR TITLE
Adjust navigation dropdown and life wheel interactions

### DIFF
--- a/style.css
+++ b/style.css
@@ -26,8 +26,8 @@ img{max-width:100%;display:block}
 .nav-link.active{background:#1d4ed8;color:#fff;box-shadow:0 12px 26px rgba(37,99,235,.26)}
 .nav-link--browse::after{content:"▾";font-size:.68em;margin-left:6px;transition:transform .2s ease}
 .nav-item--browse.is-open>.nav-link--browse::after,.nav-item--browse:hover>.nav-link--browse::after{transform:rotate(180deg)}
-.nav-item--browse .nav-mega{position:absolute;top:calc(100% + 14px);left:0;width:min(760px,calc(100vw - 40px));background:rgba(255,255,255,.98);border-radius:22px;border:1px solid rgba(148,163,184,.26);box-shadow:0 32px 68px rgba(15,23,42,.18);padding:24px;opacity:0;transform:translateY(10px);pointer-events:none;visibility:hidden;transition:opacity .2s ease,transform .2s ease,visibility .2s ease;z-index:70}
-.nav-item--browse:hover .nav-mega,.nav-item--browse:focus-within .nav-mega,.nav-item--browse.is-open .nav-mega{opacity:1;transform:translateY(0);pointer-events:auto;visibility:visible}
+.nav-item--browse .nav-mega{position:absolute;top:calc(100% + 14px);left:0;width:min(760px,calc(100vw - 40px));background:rgba(255,255,255,.98);border-radius:22px;border:1px solid rgba(148,163,184,.26);box-shadow:0 32px 68px rgba(15,23,42,.18);padding:24px;opacity:0;transform:translate3d(0,10px,0);pointer-events:none;visibility:hidden;transition:opacity .2s ease,transform .2s ease,visibility .2s ease;z-index:70}
+.nav-item--browse:hover .nav-mega,.nav-item--browse:focus-within .nav-mega,.nav-item--browse.is-open .nav-mega{opacity:1;transform:translate3d(0,0,0);pointer-events:auto;visibility:visible}
 .nav-mega__content{display:grid;gap:18px}
 .nav-mega__grid{display:grid;gap:18px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
 .nav-mega__group{border-radius:18px;padding:18px;background:linear-gradient(150deg,var(--area-soft,#eef2ff) 0%,#fff 100%);border:1px solid var(--area-border,rgba(148,163,184,.2));box-shadow:0 18px 36px rgba(15,23,42,.08);display:flex;flex-direction:column;gap:12px;min-height:190px}
@@ -73,11 +73,12 @@ img{max-width:100%;display:block}
 .life-wheel__graphic{position:relative;width:min(420px,100%);filter:drop-shadow(0 24px 45px rgba(79,114,205,.18))}
 .life-wheel__graphic svg{width:100%;height:auto;display:block}
 .life-wheel__icons{position:absolute;inset:0;pointer-events:none}
-.life-wheel__labels{position:absolute;inset:0;pointer-events:none;z-index:3}
-.life-wheel__label{position:absolute;top:var(--label-y,50%);left:var(--label-x,50%);transform:translate(-50%,-50%);font-size:var(--label-font-size,.95rem);font-weight:600;letter-spacing:.01em;color:rgba(30,41,59,.7);background:rgba(255,255,255,.78);border-radius:999px;padding:6px 14px;border:1px solid rgba(148,163,184,.32);box-shadow:0 18px 36px rgba(15,23,42,.08);text-align:center;max-width:150px;line-height:1.3;transition:color .3s ease,border-color .3s ease,box-shadow .3s ease,background .3s ease,opacity .3s ease,transform .3s ease;opacity:.82}
+.life-wheel__labels{position:absolute;inset:0;z-index:3;pointer-events:none}
+.life-wheel__label{position:absolute;top:var(--label-y,50%);left:var(--label-x,50%);transform:translate(-50%,-50%);font-size:var(--label-font-size,.95rem);font-weight:600;letter-spacing:.01em;color:rgba(30,41,59,.7);background:rgba(255,255,255,.78);border-radius:999px;padding:6px 14px;border:1px solid rgba(148,163,184,.32);box-shadow:0 18px 36px rgba(15,23,42,.08);text-align:center;max-width:150px;line-height:1.3;transition:color .3s ease,border-color .3s ease,box-shadow .3s ease,background .3s ease,opacity .3s ease,transform .3s ease;opacity:.82;pointer-events:auto;display:inline-flex;align-items:center;justify-content:center;text-decoration:none}
 .life-wheel__label[data-align="left"]{text-align:right}
 .life-wheel__label[data-align="right"]{text-align:left}
-.life-wheel__label.is-active{color:var(--area-color,#1d4ed8);border-color:var(--area-color,#6366f1);background:#fff;box-shadow:0 24px 46px var(--area-glow,rgba(99,102,241,.18));opacity:1;transform:translate(-50%,-50%) scale(1.02)}
+.life-wheel__label.is-active,.life-wheel__label:hover,.life-wheel__label:focus-visible{color:var(--area-color,#1d4ed8);border-color:var(--area-color,#6366f1);background:#fff;box-shadow:0 24px 46px var(--area-glow,rgba(99,102,241,.18));opacity:1;transform:translate(-50%,-50%) scale(1.02)}
+.life-wheel__label:focus-visible{outline:none}
 
 .life-wheel__icon{position:absolute;top:var(--icon-y,50%);left:var(--icon-x,50%);width:var(--icon-size,64px);height:var(--icon-size,64px);transform:translate(-50%,-50%);transition:opacity .3s ease}
 .life-wheel__icon-inner{width:100%;height:100%;border-radius:calc(var(--icon-size,64px)*.32);background:var(--area-color);color:#fff;display:flex;align-items:center;justify-content:center;box-shadow:0 16px 32px var(--area-glow);transform:scale(.88);transition:transform .3s ease,box-shadow .3s ease,opacity .3s ease;opacity:.82}
@@ -136,8 +137,7 @@ img{max-width:100%;display:block}
   .nav-link:hover,.nav-link:focus-visible{background:#e0e7ff;box-shadow:none}
   .nav-link.active{background:#dbeafe;color:#1d4ed8}
   .nav-item--browse .nav-link--browse::after{transform:none}
-  .nav-item--browse .nav-mega{position:static;width:100%;margin-top:10px;padding:16px;border-radius:16px;border:1px solid rgba(148,163,184,.26);box-shadow:none;opacity:1;transform:none;visibility:visible;pointer-events:auto;display:none;background:#f8faff}
-  .nav-item--browse.is-open .nav-mega{display:block}
+  .nav-item--browse .nav-mega{display:none!important;pointer-events:none!important;visibility:hidden!important}
   .nav-mega__grid{grid-template-columns:1fr}
   .nav-mega__group{min-height:auto}
   .nav-mega__footer{justify-content:flex-start}


### PR DESCRIPTION
## Summary
- clamp the browse mega menu within the viewport and disable the dropdown on narrow screens so the link navigates directly
- restyle the navigation dropdown for the new behavior and hide it entirely on phones
- turn Life Harmony Wheel labels into interactive links that mirror slice hover/tap behavior and update their styling

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68cfe4d84aa8832d8c91ffb0e5efcd3e