### PR TITLE
Adjust mega menu layout and content

### DIFF
--- a/app.js
+++ b/app.js
@@ -128,7 +128,13 @@ App.LIFE_AREAS = {
     description: "Create rituals and check-ins that nurture meaningful partnerships.",
     link: "products.html?area=love",
     cta: "Explore relationship tools",
-    empty: "We're crafting dedicated templates for Love & Romantic Relationships. In the meantime, explore all Life Harmony tools."
+    empty: "We're crafting dedicated templates for Love & Romantic Relationships. In the meantime, explore all Life Harmony tools.",
+    menuQuestion: "Craving more moments that feel close and connected?",
+    menuHighlights: [
+      "Daily affection rituals",
+      "Meaningful check-in prompts",
+      "Shared memory keepers"
+    ]
   },
   career: {
     title: "Career, Growth & Learning",
@@ -138,7 +144,13 @@ App.LIFE_AREAS = {
     description: "Stay organized, track goals, and keep moving toward your next milestone.",
     link: "products.html?area=career",
     cta: "Stay on track with career tools",
-    empty: "We're designing more templates for Career, Growth & Learning. Browse all tools while we build."
+    empty: "We're designing more templates for Career, Growth & Learning. Browse all tools while we build.",
+    menuQuestion: "Trying to stay focused on what moves your career forward?",
+    menuHighlights: [
+      "Skill-building trackers",
+      "Project milestone planners",
+      "Weekly review rituals"
+    ]
   },
   health: {
     title: "Health & Fitness",
@@ -148,7 +160,13 @@ App.LIFE_AREAS = {
     description: "Build calm routines for movement, rest, and mindful habits.",
     link: "products.html?area=health",
     cta: "See wellness templates",
-    empty: "We're creating new wellness planners for this area. Explore all Life Harmony tools to get started."
+    empty: "We're creating new wellness planners for this area. Explore all Life Harmony tools to get started.",
+    menuQuestion: "Wish your wellness routine felt consistent and kind?",
+    menuHighlights: [
+      "Gentle habit loops",
+      "Meal & movement maps",
+      "Rest and recovery check-ins"
+    ]
   },
   finances: {
     title: "Finances",
@@ -158,7 +176,13 @@ App.LIFE_AREAS = {
     description: "See your money clearly and plan budgets that match your values.",
     link: "products.html?area=finances",
     cta: "Review finance planners",
-    empty: "More money clarity tools are coming soon. Until then, browse the full collection."
+    empty: "More money clarity tools are coming soon. Until then, browse the full collection.",
+    menuQuestion: "Always uncertain about how much you have left each month?",
+    menuHighlights: [
+      "Clarity-first budget templates",
+      "Monthly cash-flow snapshots",
+      "Savings goal scorecards"
+    ]
   },
   fun: {
     title: "Fun & Recreation",
@@ -168,7 +192,13 @@ App.LIFE_AREAS = {
     description: "Plan adventures, hobbies, and creative breaks that refill your energy.",
     link: "products.html?area=fun",
     cta: "Find fun & recreation ideas",
-    empty: "We're crafting playful planners for Fun & Recreation. Explore all tools while we finish them."
+    empty: "We're crafting playful planners for Fun & Recreation. Explore all tools while we finish them.",
+    menuQuestion: "Need a nudge to plan joy between the busy weeks?",
+    menuHighlights: [
+      "Weekend adventure planners",
+      "Creative hobby dashboards",
+      "Memory-making bucket lists"
+    ]
   },
   family: {
     title: "Family & Friends",
@@ -178,7 +208,13 @@ App.LIFE_AREAS = {
     description: "Coordinate family schedules and stay connected with the people who matter most.",
     link: "products.html?area=family",
     cta: "Coordinate with family tools",
-    empty: "We're building new ways to support Family & Friends. Browse all tools to see what's ready now."
+    empty: "We're building new ways to support Family & Friends. Browse all tools to see what's ready now.",
+    menuQuestion: "Want everyone's schedules to finally sync up?",
+    menuHighlights: [
+      "Shared family agendas",
+      "Celebration planning notes",
+      "Connection ritual ideas"
+    ]
   },
   environment: {
     title: "Physical Environment",
@@ -188,7 +224,13 @@ App.LIFE_AREAS = {
     description: "Design supportive spaces, tidy routines, and home projects with clarity.",
     link: "products.html?area=environment",
     cta: "Design your ideal space",
-    empty: "Fresh templates for your environment are on the way. Check out the full library in the meantime."
+    empty: "Fresh templates for your environment are on the way. Check out the full library in the meantime.",
+    menuQuestion: "Ready to refresh the spaces you spend the most time in?",
+    menuHighlights: [
+      "Room reset routines",
+      "Seasonal declutter checklists",
+      "Home project planners"
+    ]
   },
   spirituality: {
     title: "Spirituality & Community",
@@ -198,7 +240,13 @@ App.LIFE_AREAS = {
     description: "Cultivate reflection, service, and community practices that ground you.",
     link: "products.html?area=spirituality",
     cta: "Discover community & reflection tools",
-    empty: "We're preparing new resources for Spirituality & Community. Explore all tools while we build."
+    empty: "We're preparing new resources for Spirituality & Community. Explore all tools while we build.",
+    menuQuestion: "Longing for a rhythm that keeps you grounded and giving?",
+    menuHighlights: [
+      "Mindful reflection journals",
+      "Community service trackers",
+      "Gratitude & intention prompts"
+    ]
   }
 };
 
@@ -347,6 +395,7 @@ App.initNavDropdown = function() {
   const resetMegaPosition = () => {
     mega.style.left = "";
     mega.style.right = "";
+    mega.style.removeProperty("--mega-adjust");
   };
 
   const repositionMega = () => {
@@ -355,10 +404,8 @@ App.initNavDropdown = function() {
 
     const margin = 20;
     const rect = mega.getBoundingClientRect();
-    const itemRect = browseItem.getBoundingClientRect();
     const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
 
-    let offset = rect.left - itemRect.left;
     let shift = 0;
 
     if (rect.left < margin) {
@@ -368,8 +415,9 @@ App.initNavDropdown = function() {
     }
 
     if (Math.abs(shift) > 0.5) {
-      offset += shift;
-      mega.style.left = `${offset}px`;
+      mega.style.setProperty("--mega-adjust", `${shift}px`);
+    } else {
+      mega.style.removeProperty("--mega-adjust");
     }
   };
 
@@ -428,31 +476,16 @@ App.initNavDropdown = function() {
     close();
   });
 
-  const render = products => {
-    const byArea = {};
-    Object.keys(App.LIFE_AREAS).forEach(key => {
-      byArea[key] = [];
-    });
-
-    products.forEach(product => {
-      if (!Array.isArray(product.lifeAreas)) return;
-      product.lifeAreas.forEach(area => {
-        if (byArea[area]) byArea[area].push(product);
-      });
-    });
-
-    Object.values(byArea).forEach(list => {
-      list.sort((a, b) => a.name.localeCompare(b.name));
-    });
-
+  const render = () => {
     const groups = Object.entries(App.LIFE_AREAS)
-      .map(([key, info]) => {
-        const items = byArea[key] || [];
-        const productMarkup = items.length
-          ? items
-              .map(p => `<li><a href="product.html?id=${p.id}">${p.name}</a></li>`)
-              .join("")
-          : '<li class="nav-mega__empty">Tools coming soon</li>';
+      .map(([, info]) => {
+        const highlights = Array.isArray(info.menuHighlights) ? info.menuHighlights : [];
+        const highlightMarkup = highlights.length
+          ? highlights.map(item => `<li>${item}</li>`).join("")
+          : '<li class="nav-mega__empty">Fresh tools coming soon</li>';
+        const questionMarkup = info.menuQuestion
+          ? `<p class="nav-mega__question">${info.menuQuestion}</p>`
+          : "";
         const soft = App.hexToRgba(info.color, 0.12);
         const border = App.hexToRgba(info.color, 0.24);
         const ink = App.hexToRgba(info.color, 0.7);
@@ -462,7 +495,8 @@ App.initNavDropdown = function() {
               <span class="nav-mega__badge">${info.short || info.title}</span>
               <span class="nav-mega__label">${info.title}</span>
             </header>
-            <ul class="nav-mega__products">${productMarkup}</ul>
+            ${questionMarkup}
+            <ul class="nav-mega__products">${highlightMarkup}</ul>
             <a class="nav-mega__area-link" href="${info.link}">Open ${info.short || info.title} tools</a>
           </section>
         `;
@@ -478,15 +512,11 @@ App.initNavDropdown = function() {
     scheduleReposition();
   };
 
-  App.loadProducts()
-    .then(products => {
-      render(products);
-    })
-    .catch(err => {
-      console.error("Error building browse menu:", err);
-      content.innerHTML = '<p class="nav-mega__placeholder">Unable to load tools right now.</p>';
-      scheduleReposition();
-    });
+  render();
+
+  App.loadProducts().catch(err => {
+    console.warn("Unable to preload products:", err);
+  });
 };
 
 /*****************************************************

--- a/style.css
+++ b/style.css
@@ -26,23 +26,23 @@ img{max-width:100%;display:block}
 .nav-link.active{background:#1d4ed8;color:#fff;box-shadow:0 12px 26px rgba(37,99,235,.26)}
 .nav-link--browse::after{content:"▾";font-size:.68em;margin-left:6px;transition:transform .2s ease}
 .nav-item--browse.is-open>.nav-link--browse::after,.nav-item--browse:hover>.nav-link--browse::after{transform:rotate(180deg)}
-.nav-item--browse .nav-mega{position:absolute;top:calc(100% + 14px);left:0;width:min(760px,calc(100vw - 40px));background:rgba(255,255,255,.98);border-radius:22px;border:1px solid rgba(148,163,184,.26);box-shadow:0 32px 68px rgba(15,23,42,.18);padding:24px;opacity:0;transform:translate3d(0,10px,0);pointer-events:none;visibility:hidden;transition:opacity .2s ease,transform .2s ease,visibility .2s ease;z-index:70}
-.nav-item--browse:hover .nav-mega,.nav-item--browse:focus-within .nav-mega,.nav-item--browse.is-open .nav-mega{opacity:1;transform:translate3d(0,0,0);pointer-events:auto;visibility:visible}
-.nav-mega__content{display:grid;gap:18px}
-.nav-mega__grid{display:grid;gap:18px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
-.nav-mega__group{border-radius:18px;padding:18px;background:linear-gradient(150deg,var(--area-soft,#eef2ff) 0%,#fff 100%);border:1px solid var(--area-border,rgba(148,163,184,.2));box-shadow:0 18px 36px rgba(15,23,42,.08);display:flex;flex-direction:column;gap:12px;min-height:190px}
+.nav-item--browse .nav-mega{position:absolute;top:calc(100% + 14px);left:50%;width:min(1040px,calc(100vw - 48px));background:rgba(255,255,255,.98);border-radius:22px;border:1px solid rgba(148,163,184,.26);box-shadow:0 32px 68px rgba(15,23,42,.18);padding:28px;opacity:0;--mega-adjust:0px;transform:translate3d(calc(-50% + var(--mega-adjust,0px)),10px,0);pointer-events:none;visibility:hidden;transition:opacity .2s ease,transform .2s ease,visibility .2s ease;z-index:70}
+.nav-item--browse:hover .nav-mega,.nav-item--browse:focus-within .nav-mega,.nav-item--browse.is-open .nav-mega{opacity:1;transform:translate3d(calc(-50% + var(--mega-adjust,0px)),0,0);pointer-events:auto;visibility:visible}
+.nav-mega__content{display:grid;gap:24px}
+.nav-mega__grid{display:grid;gap:18px;grid-template-columns:repeat(4,minmax(0,1fr));max-width:960px;margin:0 auto}
+.nav-mega__group{border-radius:18px;padding:20px;background:linear-gradient(150deg,var(--area-soft,#eef2ff) 0%,#fff 100%);border:1px solid var(--area-border,rgba(148,163,184,.2));box-shadow:0 18px 36px rgba(15,23,42,.08);display:flex;flex-direction:column;gap:14px;min-height:210px}
 .nav-mega__heading{display:flex;align-items:center;justify-content:space-between;gap:8px;flex-wrap:wrap}
 .nav-mega__badge{display:inline-flex;align-items:center;gap:4px;padding:4px 10px;border-radius:999px;background:var(--area-color,#6366f1);color:#fff;font-size:.75rem;font-weight:600;box-shadow:0 8px 18px var(--area-border,rgba(99,102,241,.2))}
 .nav-mega__label{font-size:1rem;font-weight:600;color:#0f172a}
-.nav-mega__products{list-style:none;margin:0;padding:0;display:grid;gap:6px}
-.nav-mega__products a{display:flex;align-items:center;gap:6px;padding:7px 12px;border-radius:10px;background:rgba(255,255,255,.9);border:1px solid rgba(148,163,184,.22);color:#1f2937;font-size:.92rem;font-weight:500;transition:border-color .2s ease,background .2s ease,color .2s ease,transform .2s ease}
-.nav-mega__products a::before{content:"•";color:var(--area-ink,var(--area-color,#6366f1));font-size:.8rem;transform:translateY(-1px)}
-.nav-mega__products a:hover,.nav-mega__products a:focus-visible{background:var(--area-soft,#eef2ff);border-color:var(--area-color,#6366f1);color:var(--area-color,#6366f1);transform:translateY(-1px)}
-.nav-mega__empty{color:#64748b;font-size:.9rem;padding:6px 0}
+.nav-mega__question{margin:0;font-size:.95rem;font-weight:500;color:var(--area-ink,var(--area-color,#475569));line-height:1.4}
+.nav-mega__products{list-style:none;margin:0;padding:0;display:grid;gap:8px}
+.nav-mega__products li{display:flex;align-items:flex-start;gap:10px;padding:9px 12px;border-radius:12px;background:rgba(255,255,255,.9);border:1px solid rgba(148,163,184,.22);color:#1f2937;font-size:.92rem;font-weight:500;line-height:1.35;box-shadow:0 10px 24px rgba(15,23,42,.06)}
+.nav-mega__products li::before{content:"•";color:var(--area-ink,var(--area-color,#6366f1));font-size:.95rem;line-height:1;transform:translateY(2px)}
+.nav-mega__empty{color:#64748b;font-size:.9rem;padding:4px 0}
 .nav-mega__area-link{margin-top:auto;align-self:flex-start;font-weight:600;font-size:.92rem;color:var(--area-color,#4338ca);display:inline-flex;align-items:center;gap:6px}
 .nav-mega__area-link::after{content:"→"}
 .nav-mega__placeholder{margin:0;color:#475569}
-.nav-mega__footer{display:flex;justify-content:flex-end;padding-top:12px;border-top:1px solid rgba(148,163,184,.2)}
+.nav-mega__footer{display:flex;justify-content:center;padding-top:12px;border-top:1px solid rgba(148,163,184,.2)}
 .nav-mega__footer a{font-weight:600;color:#1d4ed8}
 .sr-only{position:absolute;width:1px;height:1px;padding:0;margin:-1px;overflow:hidden;clip:rect(0,0,0,0);white-space:nowrap;border:0}
 .nav-toggle{display:none;align-items:center;justify-content:center;border:1px solid var(--border);background:#fff;border-radius:10px;width:44px;height:44px;padding:0;cursor:pointer;transition:box-shadow .2s ease,border-color .2s ease}
@@ -56,6 +56,10 @@ img{max-width:100%;display:block}
 .nav-toggle.is-open .nav-toggle__icon{background:transparent}
 .nav-toggle.is-open .nav-toggle__icon::before{transform:translateY(0) rotate(45deg)}
 .nav-toggle.is-open .nav-toggle__icon::after{transform:translateY(0) rotate(-45deg)}
+
+@media(max-width:1040px){
+  .nav-mega__grid{grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+}
 
 .hero.minimal{padding:70px 24px;text-align:center;max-width:920px;margin:0 auto}
 .hero h1{margin:0 0 10px;font-size:42px;line-height:1.1}


### PR DESCRIPTION
## Summary
- curate mega menu content with category-specific prompts and highlight bullet points in place of individual product links
- center the browse dropdown and lock it to a two-row, four-column layout with refreshed styling for list items and footer

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d00ddc9fe8832daccbb7b76897ef6a