### PR TITLE
Add marketing footer and policy pages

### DIFF
--- a/affiliate.html
+++ b/affiliate.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>About — Harmony Sheets</title>
+  <title>Affiliate Program — Harmony Sheets</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="style.css">
 </head>
-<body class="theme-neutral">
+<body class="theme-neutral page-affiliate">
 <header class="site-header">
   <a class="brand" href="/">Harmony Sheets</a>
   <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">
@@ -59,15 +59,56 @@
   </div>
 </aside>
 
-<main class="about">
-  <h1>Our belief</h1>
-  <p>At Harmony Sheets we believe organization should be easy and affordable. No subscriptions, no lock-in — just beautifully crafted tools that help you think clearly and act quickly.</p>
-  <ul class="bullets">
-    <li>App interface on top, spreadsheet database underneath.</li>
-    <li>Fast to learn, delightful to use.</li>
-    <li>Four visual looks: Pink/Feminine, Masculine, Neutral, Colorful.</li>
-  </ul>
-  <p>Questions? <a href="faq.html">Visit Support</a> or write via the form.</p>
+<main>
+  <section id="apply" class="affiliate-hero anchor-section">
+    <h1>Partner with Harmony Sheets</h1>
+    <p>Earn recurring commissions by recommending calm, app-like spreadsheet tools. Our templates help customers see their lives clearly without the pressure of subscriptions.</p>
+    <div class="actions">
+      <a class="btn primary" href="mailto:partners@harmony-sheets.com?subject=Affiliate%20Application">Apply now</a>
+      <a class="btn ghost" href="#login">Affiliate portal</a>
+    </div>
+    <div class="meta">
+      <span>25% commission on every sale</span>
+      <span>30-day tracking cookies</span>
+      <span>Monthly PayPal payouts</span>
+    </div>
+  </section>
+
+  <section class="affiliate-section affiliate-benefits anchor-section" id="benefits">
+    <h2>Why partners choose Harmony Sheets</h2>
+    <div class="affiliate-grid">
+      <article class="affiliate-card">
+        <h3>High-converting templates</h3>
+        <p>Our product pages highlight the transformation customers can expect. Affiliates regularly see above-average conversion rates because buyers know exactly what they’re getting.</p>
+      </article>
+      <article class="affiliate-card">
+        <h3>Fresh launches &amp; promos</h3>
+        <p>We release new planners and life-area bundles every season. You’ll receive launch assets, swipe copy, and early previews to keep your audience inspired.</p>
+      </article>
+      <article class="affiliate-card">
+        <h3>Supportive onboarding</h3>
+        <p>Need custom graphics or tailored copy? We’ll work with you on co-branded assets so your recommendations feel natural to your community.</p>
+      </article>
+    </div>
+  </section>
+
+  <section class="affiliate-section affiliate-highlight anchor-section" id="how-it-works">
+    <h2>How it works</h2>
+    <ol class="affiliate-steps">
+      <li>Apply with details about your audience and the channels you use.</li>
+      <li>Receive your unique tracking links, media kit, and launch calendar.</li>
+      <li>Share Harmony Sheets in newsletters, social posts, videos, or workshops.</li>
+      <li>Track clicks and commissions in real time, with payouts delivered monthly.</li>
+    </ol>
+    <p>We’ll share proven angles, best-performing bundles, and ongoing product updates so you always have something valuable to promote.</p>
+  </section>
+
+  <section id="login" class="affiliate-login anchor-section">
+    <h2>Affiliate Login</h2>
+    <p>Already part of the program? Head to the partner dashboard to grab fresh links, review stats, or download campaign assets.</p>
+    <a class="btn primary" href="https://partners.harmony-sheets.com/login" target="_blank" rel="noopener">Open partner portal</a>
+    <p class="muted">Need help? Email <a href="mailto:partners@harmony-sheets.com">partners@harmony-sheets.com</a> and we’ll get you sorted.</p>
+  </section>
 </main>
 
 <footer class="site-footer">
@@ -143,7 +184,7 @@
     </div>
   </div>
 </footer>
+
 <script src="app.js"></script>
-<script>App.initStatic()</script>
 </body>
 </html>

--- a/app.js
+++ b/app.js
@@ -584,6 +584,23 @@ App.init = function() {
   const yearEl = App.qs("#year");
   if (yearEl) yearEl.textContent = new Date().getFullYear();
 
+  // Footer newsletter form
+  const newsletterForm = App.qs("#footer-newsletter");
+  if (newsletterForm) {
+    const status = App.qs("#footer-newsletter-status");
+    newsletterForm.addEventListener("submit", event => {
+      event.preventDefault();
+      const formData = new FormData(newsletterForm);
+      const email = formData.get("email");
+      if (status) {
+        status.textContent = email
+          ? `Thanks, ${email}! We'll be in touch soon.`
+          : "Thanks! We'll be in touch soon.";
+      }
+      newsletterForm.reset();
+    });
+  }
+
   // Highlight active nav item
   const path = window.location.pathname;
   const filename = path === "/" ? "index.html" : path.split("/").pop();

--- a/bundles.html
+++ b/bundles.html
@@ -64,7 +64,79 @@
   <div id="bundles-grid" class="cards"></div>
 </main>
 
-<footer class="site-footer"><p>© <span id="year"></span> Harmony Sheets</p></footer>
+<footer class="site-footer">
+  <div class="site-footer__inner">
+    <div class="site-footer__grid">
+      <div class="site-footer__column">
+        <h3 class="site-footer__heading">Customer Support</h3>
+        <ul class="site-footer__links">
+          <li><a href="faq.html#guides">Information Guides</a></li>
+          <li><a href="faq.html">FAQ / Support</a></li>
+          <li><a href="faq.html#contact">Contact Us</a></li>
+        </ul>
+      </div>
+      <div class="site-footer__column">
+        <h3 class="site-footer__heading">Policies</h3>
+        <ul class="site-footer__links">
+          <li><a href="policies.html#privacy">Privacy Policy</a></li>
+          <li><a href="policies.html#delivery">Delivery Policy</a></li>
+          <li><a href="policies.html#refund">Refund Policy</a></li>
+          <li><a href="policies.html#terms">Terms of Service</a></li>
+        </ul>
+      </div>
+      <div class="site-footer__column">
+        <h3 class="site-footer__heading">Affiliate</h3>
+        <ul class="site-footer__links">
+          <li><a href="affiliate.html#apply">Become an Affiliate</a></li>
+          <li><a href="affiliate.html#login">Affiliate Login</a></li>
+        </ul>
+      </div>
+      <div class="site-footer__column site-footer__column--newsletter">
+        <h3 class="site-footer__heading">Social &amp; Newsletter</h3>
+        <form id="footer-newsletter" class="footer-form">
+          <label class="sr-only" for="footer-email">Email address</label>
+          <div class="footer-form__controls">
+            <input id="footer-email" type="email" name="email" placeholder="Enter email" required>
+            <button type="submit" class="footer-form__submit">Join</button>
+          </div>
+        </form>
+        <p class="site-footer__note">Subscribe to receive exclusive releases, deals, and event updates.</p>
+        <div class="site-footer__social">
+          <a class="site-footer__social-link" href="https://www.instagram.com/harmonysheets" target="_blank" rel="noopener" aria-label="Instagram">
+            <span aria-hidden="true">IG</span>
+          </a>
+          <a class="site-footer__social-link" href="https://www.youtube.com/@HarmonySheets" target="_blank" rel="noopener" aria-label="YouTube">
+            <span aria-hidden="true">YT</span>
+          </a>
+          <a class="site-footer__social-link" href="https://www.pinterest.com/harmonysheets" target="_blank" rel="noopener" aria-label="Pinterest">
+            <span aria-hidden="true">PI</span>
+          </a>
+          <a class="site-footer__social-link" href="mailto:support@harmony-sheets.com" aria-label="Email Harmony Sheets">
+            <span aria-hidden="true">@</span>
+          </a>
+        </div>
+        <p id="footer-newsletter-status" class="site-footer__status" role="status" aria-live="polite"></p>
+      </div>
+    </div>
+    <div class="site-footer__bottom">
+      <div class="site-footer__brand">
+        <a class="brand brand--footer" href="/">Harmony Sheets</a>
+        <p class="site-footer__copy">© <span id="year"></span> Harmony Sheets. All rights reserved.</p>
+        <p class="site-footer__tagline">One-time purchase. No subscriptions.</p>
+      </div>
+      <div class="site-footer__extras">
+        <p class="site-footer__locale">Serving customers worldwide • USD</p>
+        <div class="site-footer__payments">
+          <span class="site-footer__payment">Visa</span>
+          <span class="site-footer__payment">Mastercard</span>
+          <span class="site-footer__payment">Amex</span>
+          <span class="site-footer__payment">PayPal</span>
+          <span class="site-footer__payment">Shop Pay</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</footer>
 <script src="app.js"></script>
 <script>App.initBundles()</script>
 </body>

--- a/faq.html
+++ b/faq.html
@@ -60,24 +60,130 @@
 </aside>
 
 <main class="faq">
-  <h1>FAQ / Support</h1>
-  <details open><summary>Do I need a subscription?</summary><p>No. All products are a one-time purchase. You own the files.</p></details>
-  <details><summary>Which apps do these spreadsheets use?</summary><p>Google Sheets first; many also work in Excel. Each product page lists compatibility.</p></details>
-  <details><summary>Can I get updates?</summary><p>Yes. Minor updates are free. We email buyers or post on product pages.</p></details>
-  <details><summary>Refunds?</summary><p>If a product doesn’t work as described and we can’t fix it, we’ll make it right.</p></details>
+  <header class="faq-header">
+    <h1>FAQ / Support</h1>
+    <p>We’re here to help you get the most from Harmony Sheets. Browse quick-start guides, answers, and reach out if you need a hand.</p>
+  </header>
 
-  <h2>Contact</h2>
-  <form id="support-form" class="support">
-    <input name="name" placeholder="Your name">
-    <input name="email" type="email" required placeholder="Email">
-    <input name="order" placeholder="Order # (optional)">
-    <textarea name="message" rows="4" required placeholder="How can we help?"></textarea>
-    <button class="btn primary">Send</button>
-    <p id="support-status" class="muted"></p>
-  </form>
+  <section id="guides" class="faq-guides anchor-section">
+    <h2>Information Guides</h2>
+    <p>Start with these resources to understand how Harmony Sheets templates support every area of your life.</p>
+    <ul class="faq-guides__list">
+      <li><a href="index.html#life-wheel">Explore the Life Harmony Wheel overview</a></li>
+      <li><a href="products.html">Compare templates in the product catalog</a></li>
+      <li><a href="bundles.html">See how bundle savings are structured</a></li>
+    </ul>
+  </section>
+
+  <section id="faqs" class="faq-accordion anchor-section">
+    <h2>Frequently Asked Questions</h2>
+    <div class="faq-accordion__items">
+      <details class="faq-item" open>
+        <summary>Do I need a subscription?</summary>
+        <p>No. Harmony Sheets templates are one-time purchases. Once you create your copy, the file is yours to keep and customize.</p>
+      </details>
+      <details class="faq-item">
+        <summary>Which apps do these spreadsheets use?</summary>
+        <p>Every template is built for Google Sheets first. Many also include Excel-ready versions — check the compatibility section on each product page.</p>
+      </details>
+      <details class="faq-item">
+        <summary>Can I get updates?</summary>
+        <p>Yes. Minor updates are free. We’ll email buyers or post on the product page whenever new layouts, colors, or features are added.</p>
+      </details>
+      <details class="faq-item">
+        <summary>What if I need a refund?</summary>
+        <p>If a product doesn’t work as described, reach out. We’ll troubleshoot together, and if we can’t fix it, we’ll make it right with a refund or exchange.</p>
+      </details>
+    </div>
+  </section>
+
+  <section id="contact" class="faq-contact anchor-section">
+    <h2>Contact</h2>
+    <p>Complete the form and we’ll respond within one business day. You can also email <a href="mailto:support@harmony-sheets.com">support@harmony-sheets.com</a>.</p>
+    <form id="support-form" class="support">
+      <input name="name" placeholder="Your name">
+      <input name="email" type="email" required placeholder="Email">
+      <input name="order" placeholder="Order # (optional)">
+      <textarea name="message" rows="4" required placeholder="How can we help?"></textarea>
+      <button class="btn primary">Send</button>
+      <p id="support-status" class="muted"></p>
+    </form>
+  </section>
 </main>
 
-<footer class="site-footer"><p>© <span id="year"></span> Harmony Sheets</p></footer>
+<footer class="site-footer">
+  <div class="site-footer__inner">
+    <div class="site-footer__grid">
+      <div class="site-footer__column">
+        <h3 class="site-footer__heading">Customer Support</h3>
+        <ul class="site-footer__links">
+          <li><a href="faq.html#guides">Information Guides</a></li>
+          <li><a href="faq.html">FAQ / Support</a></li>
+          <li><a href="faq.html#contact">Contact Us</a></li>
+        </ul>
+      </div>
+      <div class="site-footer__column">
+        <h3 class="site-footer__heading">Policies</h3>
+        <ul class="site-footer__links">
+          <li><a href="policies.html#privacy">Privacy Policy</a></li>
+          <li><a href="policies.html#delivery">Delivery Policy</a></li>
+          <li><a href="policies.html#refund">Refund Policy</a></li>
+          <li><a href="policies.html#terms">Terms of Service</a></li>
+        </ul>
+      </div>
+      <div class="site-footer__column">
+        <h3 class="site-footer__heading">Affiliate</h3>
+        <ul class="site-footer__links">
+          <li><a href="affiliate.html#apply">Become an Affiliate</a></li>
+          <li><a href="affiliate.html#login">Affiliate Login</a></li>
+        </ul>
+      </div>
+      <div class="site-footer__column site-footer__column--newsletter">
+        <h3 class="site-footer__heading">Social &amp; Newsletter</h3>
+        <form id="footer-newsletter" class="footer-form">
+          <label class="sr-only" for="footer-email">Email address</label>
+          <div class="footer-form__controls">
+            <input id="footer-email" type="email" name="email" placeholder="Enter email" required>
+            <button type="submit" class="footer-form__submit">Join</button>
+          </div>
+        </form>
+        <p class="site-footer__note">Subscribe to receive exclusive releases, deals, and event updates.</p>
+        <div class="site-footer__social">
+          <a class="site-footer__social-link" href="https://www.instagram.com/harmonysheets" target="_blank" rel="noopener" aria-label="Instagram">
+            <span aria-hidden="true">IG</span>
+          </a>
+          <a class="site-footer__social-link" href="https://www.youtube.com/@HarmonySheets" target="_blank" rel="noopener" aria-label="YouTube">
+            <span aria-hidden="true">YT</span>
+          </a>
+          <a class="site-footer__social-link" href="https://www.pinterest.com/harmonysheets" target="_blank" rel="noopener" aria-label="Pinterest">
+            <span aria-hidden="true">PI</span>
+          </a>
+          <a class="site-footer__social-link" href="mailto:support@harmony-sheets.com" aria-label="Email Harmony Sheets">
+            <span aria-hidden="true">@</span>
+          </a>
+        </div>
+        <p id="footer-newsletter-status" class="site-footer__status" role="status" aria-live="polite"></p>
+      </div>
+    </div>
+    <div class="site-footer__bottom">
+      <div class="site-footer__brand">
+        <a class="brand brand--footer" href="/">Harmony Sheets</a>
+        <p class="site-footer__copy">© <span id="year"></span> Harmony Sheets. All rights reserved.</p>
+        <p class="site-footer__tagline">One-time purchase. No subscriptions.</p>
+      </div>
+      <div class="site-footer__extras">
+        <p class="site-footer__locale">Serving customers worldwide • USD</p>
+        <div class="site-footer__payments">
+          <span class="site-footer__payment">Visa</span>
+          <span class="site-footer__payment">Mastercard</span>
+          <span class="site-footer__payment">Amex</span>
+          <span class="site-footer__payment">PayPal</span>
+          <span class="site-footer__payment">Shop Pay</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</footer>
 <script src="app.js"></script>
 <script>App.initFAQ()</script>
 </body>

--- a/index.html
+++ b/index.html
@@ -142,7 +142,77 @@
 </main>
 
 <footer class="site-footer">
-  <p>© <span id="year"></span> Harmony Sheets • One-time purchase. No subscriptions.</p>
+  <div class="site-footer__inner">
+    <div class="site-footer__grid">
+      <div class="site-footer__column">
+        <h3 class="site-footer__heading">Customer Support</h3>
+        <ul class="site-footer__links">
+          <li><a href="faq.html#guides">Information Guides</a></li>
+          <li><a href="faq.html">FAQ / Support</a></li>
+          <li><a href="faq.html#contact">Contact Us</a></li>
+        </ul>
+      </div>
+      <div class="site-footer__column">
+        <h3 class="site-footer__heading">Policies</h3>
+        <ul class="site-footer__links">
+          <li><a href="policies.html#privacy">Privacy Policy</a></li>
+          <li><a href="policies.html#delivery">Delivery Policy</a></li>
+          <li><a href="policies.html#refund">Refund Policy</a></li>
+          <li><a href="policies.html#terms">Terms of Service</a></li>
+        </ul>
+      </div>
+      <div class="site-footer__column">
+        <h3 class="site-footer__heading">Affiliate</h3>
+        <ul class="site-footer__links">
+          <li><a href="affiliate.html#apply">Become an Affiliate</a></li>
+          <li><a href="affiliate.html#login">Affiliate Login</a></li>
+        </ul>
+      </div>
+      <div class="site-footer__column site-footer__column--newsletter">
+        <h3 class="site-footer__heading">Social &amp; Newsletter</h3>
+        <form id="footer-newsletter" class="footer-form">
+          <label class="sr-only" for="footer-email">Email address</label>
+          <div class="footer-form__controls">
+            <input id="footer-email" type="email" name="email" placeholder="Enter email" required>
+            <button type="submit" class="footer-form__submit">Join</button>
+          </div>
+        </form>
+        <p class="site-footer__note">Subscribe to receive exclusive releases, deals, and event updates.</p>
+        <div class="site-footer__social">
+          <a class="site-footer__social-link" href="https://www.instagram.com/harmonysheets" target="_blank" rel="noopener" aria-label="Instagram">
+            <span aria-hidden="true">IG</span>
+          </a>
+          <a class="site-footer__social-link" href="https://www.youtube.com/@HarmonySheets" target="_blank" rel="noopener" aria-label="YouTube">
+            <span aria-hidden="true">YT</span>
+          </a>
+          <a class="site-footer__social-link" href="https://www.pinterest.com/harmonysheets" target="_blank" rel="noopener" aria-label="Pinterest">
+            <span aria-hidden="true">PI</span>
+          </a>
+          <a class="site-footer__social-link" href="mailto:support@harmony-sheets.com" aria-label="Email Harmony Sheets">
+            <span aria-hidden="true">@</span>
+          </a>
+        </div>
+        <p id="footer-newsletter-status" class="site-footer__status" role="status" aria-live="polite"></p>
+      </div>
+    </div>
+    <div class="site-footer__bottom">
+      <div class="site-footer__brand">
+        <a class="brand brand--footer" href="/">Harmony Sheets</a>
+        <p class="site-footer__copy">© <span id="year"></span> Harmony Sheets. All rights reserved.</p>
+        <p class="site-footer__tagline">One-time purchase. No subscriptions.</p>
+      </div>
+      <div class="site-footer__extras">
+        <p class="site-footer__locale">Serving customers worldwide • USD</p>
+        <div class="site-footer__payments">
+          <span class="site-footer__payment">Visa</span>
+          <span class="site-footer__payment">Mastercard</span>
+          <span class="site-footer__payment">Amex</span>
+          <span class="site-footer__payment">PayPal</span>
+          <span class="site-footer__payment">Shop Pay</span>
+        </div>
+      </div>
+    </div>
+  </div>
 </footer>
 
 <script src="app.js"></script>

--- a/policies.html
+++ b/policies.html
@@ -2,12 +2,12 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>About — Harmony Sheets</title>
+  <title>Policies — Harmony Sheets</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="style.css">
 </head>
-<body class="theme-neutral">
+<body class="theme-neutral page-policies">
 <header class="site-header">
   <a class="brand" href="/">Harmony Sheets</a>
   <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">
@@ -59,15 +59,55 @@
   </div>
 </aside>
 
-<main class="about">
-  <h1>Our belief</h1>
-  <p>At Harmony Sheets we believe organization should be easy and affordable. No subscriptions, no lock-in — just beautifully crafted tools that help you think clearly and act quickly.</p>
-  <ul class="bullets">
-    <li>App interface on top, spreadsheet database underneath.</li>
-    <li>Fast to learn, delightful to use.</li>
-    <li>Four visual looks: Pink/Feminine, Masculine, Neutral, Colorful.</li>
-  </ul>
-  <p>Questions? <a href="faq.html">Visit Support</a> or write via the form.</p>
+<main>
+  <section class="policy-hero">
+    <h1>Policies &amp; Customer Care</h1>
+    <p>We believe clarity builds trust. Here’s exactly how we protect your data, deliver digital files, handle refunds, and define our working relationship.</p>
+    <p class="policy-updated">Last updated: May 2024</p>
+  </section>
+
+  <nav class="policy-nav" aria-label="Policy quick links">
+    <a href="#privacy">Privacy Policy</a>
+    <a href="#delivery">Delivery Policy</a>
+    <a href="#refund">Refund Policy</a>
+    <a href="#terms">Terms of Service</a>
+  </nav>
+
+  <section id="privacy" class="policy-section anchor-section">
+    <h2>Privacy Policy</h2>
+    <p>Harmony Sheets collects only the information required to process your order and deliver your templates. This typically includes your name, email address, billing information, and the products purchased.</p>
+    <p>We use this data to send receipts, download links, and occasional product update announcements. We do not sell or rent your information, and access is restricted to the small Harmony Sheets team members who need it to support you.</p>
+    <ul>
+      <li><strong>Payment processing</strong> is handled by trusted third parties (such as PayPal or Stripe). We never see or store your full payment details.</li>
+      <li><strong>Analytics</strong> are anonymized and used only to understand which templates are most helpful so we can improve future releases.</li>
+      <li><strong>Email preferences</strong> are completely optional—you can unsubscribe from marketing messages at any time.</li>
+    </ul>
+  </section>
+
+  <section id="delivery" class="policy-section anchor-section">
+    <h2>Delivery Policy</h2>
+    <p>All Harmony Sheets products are digital downloads. As soon as your payment clears, the system emails you a secure link to create your own copy of the template. This link is also available immediately on the order confirmation page.</p>
+    <p>If the email doesn’t arrive within a few minutes, check your spam or promotions folder. Still missing? Reach out via <a href="mailto:support@harmony-sheets.com">support@harmony-sheets.com</a> and we’ll resend the link manually.</p>
+    <p>Links remain valid for long enough to create your copy. Once the file is in your Google Drive (or Excel), you retain full access forever.</p>
+  </section>
+
+  <section id="refund" class="policy-section anchor-section">
+    <h2>Refund Policy</h2>
+    <p>We want you to feel confident in your purchase. If a template doesn’t match its description or you encounter a technical issue we cannot resolve, contact us within 14 days and we’ll work with you on a solution.</p>
+    <ul>
+      <li><strong>Fix first:</strong> We’ll troubleshoot together, offer setup guidance, or provide an updated file if needed.</li>
+      <li><strong>Refund or exchange:</strong> When we can’t fix the issue, we’ll issue a refund or recommend a better-fitting template.</li>
+      <li><strong>Non-transferable:</strong> For fairness, completed refunds revoke access to download links and future updates.</li>
+    </ul>
+    <p>To start a refund request, email your order number and a short description of the issue to <a href="mailto:support@harmony-sheets.com">support@harmony-sheets.com</a>.</p>
+  </section>
+
+  <section id="terms" class="policy-section anchor-section">
+    <h2>Terms of Service</h2>
+    <p>By purchasing a Harmony Sheets template, you receive a personal license to use the file for yourself or within your immediate team. Templates cannot be resold, redistributed, or shared publicly.</p>
+    <p>You agree not to remove Harmony Sheets branding from the template files and not to claim the designs as your own. You’re welcome to customize worksheets for your workflow—make them your own while keeping the license terms in mind.</p>
+    <p>We reserve the right to update products, adjust pricing, or retire templates as we refine the catalog. Whenever significant changes occur, we notify current customers via email.</p>
+  </section>
 </main>
 
 <footer class="site-footer">
@@ -143,7 +183,7 @@
     </div>
   </div>
 </footer>
+
 <script src="app.js"></script>
-<script>App.initStatic()</script>
 </body>
 </html>

--- a/product.html
+++ b/product.html
@@ -149,7 +149,79 @@
     </div>
   </div>
 
-  <footer class="site-footer"><p>© <span id="year"></span> Harmony Sheets</p></footer>
+  <footer class="site-footer">
+    <div class="site-footer__inner">
+      <div class="site-footer__grid">
+        <div class="site-footer__column">
+          <h3 class="site-footer__heading">Customer Support</h3>
+          <ul class="site-footer__links">
+            <li><a href="faq.html#guides">Information Guides</a></li>
+            <li><a href="faq.html">FAQ / Support</a></li>
+            <li><a href="faq.html#contact">Contact Us</a></li>
+          </ul>
+        </div>
+        <div class="site-footer__column">
+          <h3 class="site-footer__heading">Policies</h3>
+          <ul class="site-footer__links">
+            <li><a href="policies.html#privacy">Privacy Policy</a></li>
+            <li><a href="policies.html#delivery">Delivery Policy</a></li>
+            <li><a href="policies.html#refund">Refund Policy</a></li>
+            <li><a href="policies.html#terms">Terms of Service</a></li>
+          </ul>
+        </div>
+        <div class="site-footer__column">
+          <h3 class="site-footer__heading">Affiliate</h3>
+          <ul class="site-footer__links">
+            <li><a href="affiliate.html#apply">Become an Affiliate</a></li>
+            <li><a href="affiliate.html#login">Affiliate Login</a></li>
+          </ul>
+        </div>
+        <div class="site-footer__column site-footer__column--newsletter">
+          <h3 class="site-footer__heading">Social &amp; Newsletter</h3>
+          <form id="footer-newsletter" class="footer-form">
+            <label class="sr-only" for="footer-email">Email address</label>
+            <div class="footer-form__controls">
+              <input id="footer-email" type="email" name="email" placeholder="Enter email" required>
+              <button type="submit" class="footer-form__submit">Join</button>
+            </div>
+          </form>
+          <p class="site-footer__note">Subscribe to receive exclusive releases, deals, and event updates.</p>
+          <div class="site-footer__social">
+            <a class="site-footer__social-link" href="https://www.instagram.com/harmonysheets" target="_blank" rel="noopener" aria-label="Instagram">
+              <span aria-hidden="true">IG</span>
+            </a>
+            <a class="site-footer__social-link" href="https://www.youtube.com/@HarmonySheets" target="_blank" rel="noopener" aria-label="YouTube">
+              <span aria-hidden="true">YT</span>
+            </a>
+            <a class="site-footer__social-link" href="https://www.pinterest.com/harmonysheets" target="_blank" rel="noopener" aria-label="Pinterest">
+              <span aria-hidden="true">PI</span>
+            </a>
+            <a class="site-footer__social-link" href="mailto:support@harmony-sheets.com" aria-label="Email Harmony Sheets">
+              <span aria-hidden="true">@</span>
+            </a>
+          </div>
+          <p id="footer-newsletter-status" class="site-footer__status" role="status" aria-live="polite"></p>
+        </div>
+      </div>
+      <div class="site-footer__bottom">
+        <div class="site-footer__brand">
+          <a class="brand brand--footer" href="/">Harmony Sheets</a>
+          <p class="site-footer__copy">© <span id="year"></span> Harmony Sheets. All rights reserved.</p>
+          <p class="site-footer__tagline">One-time purchase. No subscriptions.</p>
+        </div>
+        <div class="site-footer__extras">
+          <p class="site-footer__locale">Serving customers worldwide • USD</p>
+          <div class="site-footer__payments">
+            <span class="site-footer__payment">Visa</span>
+            <span class="site-footer__payment">Mastercard</span>
+            <span class="site-footer__payment">Amex</span>
+            <span class="site-footer__payment">PayPal</span>
+            <span class="site-footer__payment">Shop Pay</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  </footer>
   <script src="app.js"></script>
 </body>
 </html>

--- a/products.html
+++ b/products.html
@@ -66,7 +66,77 @@
   </main>
 
   <footer class="site-footer">
-    <p>© <span id="year"></span> Harmony Sheets</p>
+    <div class="site-footer__inner">
+      <div class="site-footer__grid">
+        <div class="site-footer__column">
+          <h3 class="site-footer__heading">Customer Support</h3>
+          <ul class="site-footer__links">
+            <li><a href="faq.html#guides">Information Guides</a></li>
+            <li><a href="faq.html">FAQ / Support</a></li>
+            <li><a href="faq.html#contact">Contact Us</a></li>
+          </ul>
+        </div>
+        <div class="site-footer__column">
+          <h3 class="site-footer__heading">Policies</h3>
+          <ul class="site-footer__links">
+            <li><a href="policies.html#privacy">Privacy Policy</a></li>
+            <li><a href="policies.html#delivery">Delivery Policy</a></li>
+            <li><a href="policies.html#refund">Refund Policy</a></li>
+            <li><a href="policies.html#terms">Terms of Service</a></li>
+          </ul>
+        </div>
+        <div class="site-footer__column">
+          <h3 class="site-footer__heading">Affiliate</h3>
+          <ul class="site-footer__links">
+            <li><a href="affiliate.html#apply">Become an Affiliate</a></li>
+            <li><a href="affiliate.html#login">Affiliate Login</a></li>
+          </ul>
+        </div>
+        <div class="site-footer__column site-footer__column--newsletter">
+          <h3 class="site-footer__heading">Social &amp; Newsletter</h3>
+          <form id="footer-newsletter" class="footer-form">
+            <label class="sr-only" for="footer-email">Email address</label>
+            <div class="footer-form__controls">
+              <input id="footer-email" type="email" name="email" placeholder="Enter email" required>
+              <button type="submit" class="footer-form__submit">Join</button>
+            </div>
+          </form>
+          <p class="site-footer__note">Subscribe to receive exclusive releases, deals, and event updates.</p>
+          <div class="site-footer__social">
+            <a class="site-footer__social-link" href="https://www.instagram.com/harmonysheets" target="_blank" rel="noopener" aria-label="Instagram">
+              <span aria-hidden="true">IG</span>
+            </a>
+            <a class="site-footer__social-link" href="https://www.youtube.com/@HarmonySheets" target="_blank" rel="noopener" aria-label="YouTube">
+              <span aria-hidden="true">YT</span>
+            </a>
+            <a class="site-footer__social-link" href="https://www.pinterest.com/harmonysheets" target="_blank" rel="noopener" aria-label="Pinterest">
+              <span aria-hidden="true">PI</span>
+            </a>
+            <a class="site-footer__social-link" href="mailto:support@harmony-sheets.com" aria-label="Email Harmony Sheets">
+              <span aria-hidden="true">@</span>
+            </a>
+          </div>
+          <p id="footer-newsletter-status" class="site-footer__status" role="status" aria-live="polite"></p>
+        </div>
+      </div>
+      <div class="site-footer__bottom">
+        <div class="site-footer__brand">
+          <a class="brand brand--footer" href="/">Harmony Sheets</a>
+          <p class="site-footer__copy">© <span id="year"></span> Harmony Sheets. All rights reserved.</p>
+          <p class="site-footer__tagline">One-time purchase. No subscriptions.</p>
+        </div>
+        <div class="site-footer__extras">
+          <p class="site-footer__locale">Serving customers worldwide • USD</p>
+          <div class="site-footer__payments">
+            <span class="site-footer__payment">Visa</span>
+            <span class="site-footer__payment">Mastercard</span>
+            <span class="site-footer__payment">Amex</span>
+            <span class="site-footer__payment">PayPal</span>
+            <span class="site-footer__payment">Shop Pay</span>
+          </div>
+        </div>
+      </div>
+    </div>
   </footer>
 
   <script src="app.js"></script>

--- a/style.css
+++ b/style.css
@@ -234,7 +234,52 @@ button.nav-link{border:0;background:transparent;cursor:pointer;font:inherit}
 .suggest input,.suggest textarea,.suggest select,.support input,.support textarea{padding:10px;border:1px solid var(--border);border-radius:8px;width:100%}
 .support{display:grid;gap:10px;max-width:720px}
 .muted{color:var(--muted)}
-.site-footer{border-top:1px solid var(--border);padding:16px 24px;color:var(--muted);text-align:center}
+.anchor-section{scroll-margin-top:120px}
+@media (max-width:640px){.anchor-section{scroll-margin-top:90px}}
+.site-footer{border-top:1px solid var(--border);background:linear-gradient(180deg,#f8fafc 0%,#fff 88%);padding:clamp(32px,5vw,56px) clamp(20px,6vw,40px) clamp(28px,6vw,48px);color:#0f172a}
+.site-footer a{color:inherit}
+.site-footer__inner{max-width:1100px;margin:0 auto;display:flex;flex-direction:column;gap:32px}
+.site-footer__grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:28px}
+.site-footer__heading{margin:0 0 14px;font-size:1rem;font-weight:600;color:#0f172a;letter-spacing:.01em}
+.site-footer__links{list-style:none;margin:0;padding:0;display:grid;gap:10px}
+.site-footer__links a{text-decoration:none;font-weight:500;color:#1f2937;transition:color .2s ease,text-decoration .2s ease}
+.site-footer__links a:hover,.site-footer__links a:focus-visible{color:#1d4ed8;text-decoration:underline}
+.site-footer__column--newsletter{display:grid;gap:14px}
+.footer-form{display:grid;gap:10px}
+.footer-form__controls{display:flex;gap:8px;align-items:center}
+.footer-form__controls input{flex:1;padding:10px 12px;border-radius:12px;border:1px solid var(--border);background:#fff;font:inherit;transition:border-color .2s ease,box-shadow .2s ease}
+.footer-form__controls input:focus{outline:2px solid var(--brand);outline-offset:2px;border-color:var(--brand)}
+.footer-form__submit{border:0;background:#1d4ed8;color:#fff;font-weight:600;padding:10px 18px;border-radius:12px;cursor:pointer;box-shadow:0 10px 24px rgba(37,99,235,.18);transition:transform .2s ease,box-shadow .2s ease,background .2s ease}
+.footer-form__submit:hover,.footer-form__submit:focus-visible{background:#1b49e3;transform:translateY(-1px);box-shadow:0 14px 26px rgba(37,99,235,.26)}
+.site-footer__note{margin:0;color:#475569;font-size:.9rem}
+.site-footer__status{margin:0;font-size:.85rem;color:#2563eb}
+.site-footer__social{display:flex;gap:10px;flex-wrap:wrap}
+.site-footer__social-link{width:38px;height:38px;border-radius:50%;border:1px solid var(--border);background:#fff;display:inline-flex;align-items:center;justify-content:center;font-weight:600;font-size:.8rem;color:#1f2937;position:relative;transition:transform .2s ease,color .2s ease,border-color .2s ease,box-shadow .2s ease}
+.site-footer__social-link:hover,.site-footer__social-link:focus-visible{color:#1d4ed8;border-color:#1d4ed8;transform:translateY(-2px);box-shadow:0 10px 20px rgba(30,64,175,.18)}
+.site-footer__social-link .sr-only{position:absolute}
+.site-footer__bottom{display:flex;align-items:flex-start;justify-content:space-between;gap:28px;padding-top:28px;border-top:1px solid var(--border);flex-wrap:wrap}
+.site-footer__brand{display:grid;gap:6px;min-width:240px}
+.site-footer__brand .brand{font-size:1.2rem;color:#0f172a}
+.site-footer__copy,.site-footer__tagline{margin:0;font-size:.95rem;color:#475569}
+.site-footer__extras{display:grid;gap:16px;justify-items:end}
+.site-footer__locale{margin:0;font-size:.9rem;color:#475569}
+.site-footer__payments{display:flex;gap:8px;flex-wrap:wrap;justify-content:flex-end}
+.site-footer__payment{display:inline-flex;align-items:center;gap:6px;padding:6px 12px;border-radius:999px;background:#fff;border:1px solid var(--border);font-size:.82rem;font-weight:600;color:#1f2937;box-shadow:0 8px 18px rgba(15,23,42,.06)}
+.site-footer__payment::before{content:"";width:8px;height:8px;border-radius:50%;background:currentColor;opacity:.26}
+@media (max-width:860px){
+  .site-footer__grid{grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+  .site-footer__extras{justify-items:start}
+}
+@media (max-width:600px){
+  .site-footer__inner{gap:28px}
+  .site-footer__grid{gap:20px}
+  .footer-form__controls{flex-direction:column;align-items:stretch}
+  .footer-form__controls input{width:100%}
+  .footer-form__submit{width:100%}
+  .site-footer__bottom{flex-direction:column;align-items:flex-start}
+  .site-footer__extras{width:100%}
+  .site-footer__payments{justify-content:flex-start}
+}
 
 /* === Product listing grid (products.html) === */
 .products-grid {
@@ -292,4 +337,80 @@ details.faq+details.faq{margin-top:10px}
 details.faq summary{cursor:pointer;font-weight:600}
 .sticky-cta{position:sticky;bottom:0;z-index:50;border-top:1px solid #eee;background:rgba(255,255,255,.85);backdrop-filter:saturate(180%) blur(8px)}
 .sticky-cta .bar{display:flex;gap:10px;align-items:center;justify-content:space-between;max-width:1080px;margin:0 auto;padding:.75rem 1rem}
-.muted{color:#777;font-size:.9rem}
+.sticky-cta .muted{color:#777;font-size:.9rem}
+
+/* === Support & policy pages === */
+.faq{max-width:900px;margin:0 auto;padding:clamp(32px,6vw,60px) clamp(20px,6vw,32px);display:grid;gap:32px}
+.faq-header{display:grid;gap:12px}
+.faq-header h1{margin:0;font-size:2.3rem;color:#0f172a}
+.faq-header p{margin:0;color:#475569;font-size:1.05rem;max-width:60ch}
+.faq-guides{background:linear-gradient(135deg,rgba(37,99,235,.08) 0%,rgba(37,99,235,.02) 100%);border-radius:20px;padding:24px;border:1px solid rgba(148,163,184,.32);box-shadow:0 20px 48px rgba(15,23,42,.08);display:grid;gap:12px}
+.faq-guides h2{margin:0;font-size:1.4rem;color:#0f172a}
+.faq-guides__list{list-style:none;margin:0;padding:0;display:grid;gap:10px}
+.faq-guides__list li{display:flex;gap:10px;align-items:flex-start;color:#475569;font-size:.98rem}
+.faq-guides__list li::before{content:"•";color:#1d4ed8;font-size:1.2rem;line-height:1;transform:translateY(1px)}
+.faq-guides__list a{color:#1d4ed8;font-weight:600}
+.faq-accordion{display:grid;gap:16px}
+.faq-accordion h2{margin:0;font-size:1.45rem;color:#0f172a}
+.faq-accordion__items{display:grid;gap:12px}
+.faq-item{border:1px solid var(--border);border-radius:18px;padding:18px;background:#fff;box-shadow:0 18px 36px rgba(15,23,42,.06)}
+.faq-item summary{cursor:pointer;font-weight:600;color:#0f172a;font-size:1.02rem;display:flex;align-items:center;justify-content:space-between;gap:12px;list-style:none}
+.faq-item summary::-webkit-details-marker{display:none}
+.faq-item summary::marker{display:none}
+.faq-item summary::after{content:"+";font-size:1.2rem;font-weight:600;color:#94a3b8;transition:transform .2s ease,color .2s ease}
+.faq-item[open] summary::after{content:"–";color:#2563eb}
+.faq-item p{margin:12px 0 0;color:#475569}
+.faq-contact{background:#fff;border:1px solid var(--border);border-radius:20px;padding:24px;box-shadow:0 22px 44px rgba(15,23,42,.08);display:grid;gap:16px}
+.faq-contact h2{margin:0;font-size:1.4rem;color:#0f172a}
+.faq-contact p{margin:0;color:#475569}
+
+/* === Affiliate page === */
+.page-affiliate main{max-width:1100px;margin:0 auto;padding:clamp(48px,6vw,76px) clamp(20px,6vw,36px);display:grid;gap:44px}
+.affiliate-hero{display:grid;gap:18px;padding:clamp(28px,6vw,42px);background:linear-gradient(135deg,rgba(59,130,246,.1) 0%,rgba(37,99,235,.03) 100%);border-radius:26px;box-shadow:0 32px 68px rgba(15,23,42,.12)}
+.affiliate-hero h1{margin:0;font-size:2.4rem;color:#0f172a}
+.affiliate-hero p{margin:0;color:#475569;font-size:1.05rem;max-width:65ch}
+.affiliate-hero .actions{display:flex;gap:12px;flex-wrap:wrap}
+.affiliate-hero .actions .btn{box-shadow:0 22px 48px rgba(37,99,235,.2)}
+.affiliate-hero .meta{display:flex;flex-wrap:wrap;gap:12px;color:#475569;font-size:.95rem}
+.affiliate-section{display:grid;gap:16px}
+.affiliate-section h2{margin:0;font-size:1.55rem;color:#0f172a}
+.affiliate-section p{margin:0;color:#475569}
+.affiliate-grid{display:grid;gap:18px;grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+.affiliate-card{background:#fff;border:1px solid var(--border);border-radius:20px;padding:22px;box-shadow:0 24px 48px rgba(15,23,42,.08);display:grid;gap:12px}
+.affiliate-card h3{margin:0;font-size:1.2rem;color:#0f172a}
+.affiliate-card p{margin:0;color:#475569;font-size:.96rem}
+.affiliate-card ul{margin:0;padding-left:20px;display:grid;gap:8px;color:#475569}
+.affiliate-steps{list-style:decimal;padding-left:22px;display:grid;gap:10px;color:#475569;font-size:.96rem}
+.affiliate-highlight{background:#f8fafc;border:1px solid var(--border);border-radius:20px;padding:24px;display:grid;gap:12px;box-shadow:0 20px 40px rgba(15,23,42,.08)}
+.affiliate-login{background:#fff;border:1px solid var(--border);border-radius:20px;padding:24px;display:grid;gap:14px;box-shadow:0 24px 48px rgba(15,23,42,.09)}
+.affiliate-login .btn{width:fit-content;padding-inline:20px}
+
+/* === Policies page === */
+.page-policies main{max-width:920px;margin:0 auto;padding:clamp(48px,6vw,82px) clamp(20px,6vw,36px);display:grid;gap:40px}
+.policy-hero{display:grid;gap:14px;text-align:center}
+.policy-hero h1{margin:0;font-size:2.5rem;color:#0f172a}
+.policy-hero p{margin:0 auto;color:#475569;font-size:1.05rem;max-width:70ch}
+.policy-nav{display:flex;flex-wrap:wrap;gap:12px;justify-content:center}
+.policy-nav a{display:inline-flex;align-items:center;justify-content:center;padding:10px 18px;border-radius:999px;border:1px solid var(--border);background:#fff;color:#1f2937;font-weight:600;box-shadow:0 20px 40px rgba(15,23,42,.08);transition:transform .2s ease,color .2s ease,border-color .2s ease}
+.policy-nav a:hover,.policy-nav a:focus-visible{color:#1d4ed8;border-color:#1d4ed8;transform:translateY(-2px)}
+.policy-section{background:#fff;border:1px solid var(--border);border-radius:24px;padding:clamp(26px,4vw,38px);box-shadow:0 24px 52px rgba(15,23,42,.1);display:grid;gap:16px}
+.policy-section h2{margin:0;font-size:1.6rem;color:#0f172a}
+.policy-section p{margin:0;color:#475569;line-height:1.65}
+.policy-section ul{margin:0;padding-left:22px;display:grid;gap:10px;color:#475569}
+.policy-section li strong{color:#0f172a}
+.policy-updated{margin:0;color:#64748b;font-size:.9rem}
+
+@media (max-width:780px){
+  .faq{gap:28px}
+  .faq-header h1{font-size:2rem}
+  .affiliate-hero h1{font-size:2.05rem}
+  .page-affiliate main{gap:36px}
+  .page-policies main{gap:32px}
+  .policy-hero h1{font-size:2.2rem}
+}
+@media (max-width:540px){
+  .affiliate-hero,.affiliate-login,.affiliate-highlight,.faq-guides,.faq-contact{padding:20px}
+  .policy-section{padding:22px}
+  .policy-nav a{width:100%}
+  .policy-hero p{font-size:1rem}
+}


### PR DESCRIPTION
## Summary
- add a global marketing footer with newsletter signup, policy links, and social badges across site pages
- create dedicated Affiliate and Policies pages with structured sections and anchor links
- refresh the FAQ/support page layout and hook the new footer form into the existing JavaScript

## Testing
- not run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d01694bd50832da2d7ac6116f3a9c9