### PR TITLE
Refine browse menu layout and labels

### DIFF
--- a/about.html
+++ b/about.html
@@ -16,7 +16,7 @@
   </button>
   <nav class="main-nav" id="site-menu">
     <div class="nav-item nav-item--browse">
-      <a class="nav-link nav-link--browse" href="products.html" aria-haspopup="true" aria-expanded="false">Browse Life Harmony Apps/Tools</a>
+      <a class="nav-link nav-link--browse" href="products.html" aria-haspopup="true" aria-expanded="false">Discover Life Harmony Apps/Templates</a>
       <div class="nav-mega" role="menu" aria-label="Life Harmony categories">
         <div class="nav-mega__content" data-nav-mega-content>
           <p class="nav-mega__placeholder">Loading Life Harmony areas…</p>

--- a/affiliate.html
+++ b/affiliate.html
@@ -16,7 +16,7 @@
   </button>
   <nav class="main-nav" id="site-menu">
     <div class="nav-item nav-item--browse">
-      <a class="nav-link nav-link--browse" href="products.html" aria-haspopup="true" aria-expanded="false">Browse Life Harmony Apps/Tools</a>
+      <a class="nav-link nav-link--browse" href="products.html" aria-haspopup="true" aria-expanded="false">Discover Life Harmony Apps/Templates</a>
       <div class="nav-mega" role="menu" aria-label="Life Harmony categories">
         <div class="nav-mega__content" data-nav-mega-content>
           <p class="nav-mega__placeholder">Loading Life Harmony areas…</p>

--- a/app.js
+++ b/app.js
@@ -713,15 +713,19 @@ App.initNavDropdown = function() {
     if (isMobile()) return;
 
     const margin = 20;
-    const rect = mega.getBoundingClientRect();
     const viewportWidth = window.innerWidth || document.documentElement.clientWidth || 0;
+    const viewportCenter = viewportWidth / 2;
+    const linkRect = browseLink.getBoundingClientRect();
+    const navCenter = linkRect.left + linkRect.width / 2;
 
-    let shift = 0;
+    let shift = viewportCenter - navCenter;
+    mega.style.setProperty("--mega-adjust", `${shift}px`);
 
+    const rect = mega.getBoundingClientRect();
     if (rect.left < margin) {
-      shift = margin - rect.left;
+      shift += margin - rect.left;
     } else if (rect.right > viewportWidth - margin) {
-      shift = viewportWidth - margin - rect.right;
+      shift -= rect.right - (viewportWidth - margin);
     }
 
     if (Math.abs(shift) > 0.5) {
@@ -791,24 +795,28 @@ App.initNavDropdown = function() {
       .map(([, info]) => {
         const highlights = Array.isArray(info.menuHighlights) ? info.menuHighlights : [];
         const highlightMarkup = highlights.length
-          ? highlights.map(item => `<li>${item}</li>`).join("")
+          ? highlights.map(item => `<li>${App.escapeHtml(item)}</li>`).join("")
           : '<li class="nav-mega__empty">Fresh tools coming soon</li>';
         const questionMarkup = info.menuQuestion
-          ? `<p class="nav-mega__question">${info.menuQuestion}</p>`
+          ? `<p class="nav-mega__question">${App.escapeHtml(info.menuQuestion)}</p>`
           : "";
         const soft = App.hexToRgba(info.color, 0.12);
         const border = App.hexToRgba(info.color, 0.24);
         const ink = App.hexToRgba(info.color, 0.7);
+        const title = App.escapeHtml(info.title || "");
+        const link = App.escapeHtml(info.link || "#");
+        const color = App.escapeHtml(info.color || "");
+        const softColor = App.escapeHtml(soft);
+        const borderColor = App.escapeHtml(border);
+        const inkColor = App.escapeHtml(ink);
         return `
-          <section class="nav-mega__group" style="--area-color:${info.color};--area-soft:${soft};--area-border:${border};--area-ink:${ink};">
+          <a class="nav-mega__group" role="menuitem" href="${link}" style="--area-color:${color};--area-soft:${softColor};--area-border:${borderColor};--area-ink:${inkColor};">
             <header class="nav-mega__heading">
-              <span class="nav-mega__badge">${info.short || info.title}</span>
-              <span class="nav-mega__label">${info.title}</span>
+              <span class="nav-mega__badge">${title}</span>
             </header>
             ${questionMarkup}
             <ul class="nav-mega__products">${highlightMarkup}</ul>
-            <a class="nav-mega__area-link" href="${info.link}">Open ${info.short || info.title} tools</a>
-          </section>
+          </a>
         `;
       })
       .join("");

--- a/bundles.html
+++ b/bundles.html
@@ -16,7 +16,7 @@
   </button>
   <nav class="main-nav" id="site-menu">
     <div class="nav-item nav-item--browse">
-      <a class="nav-link nav-link--browse" href="products.html" aria-haspopup="true" aria-expanded="false">Browse Life Harmony Apps/Tools</a>
+      <a class="nav-link nav-link--browse" href="products.html" aria-haspopup="true" aria-expanded="false">Discover Life Harmony Apps/Templates</a>
       <div class="nav-mega" role="menu" aria-label="Life Harmony categories">
         <div class="nav-mega__content" data-nav-mega-content>
           <p class="nav-mega__placeholder">Loading Life Harmony areas…</p>

--- a/faq.html
+++ b/faq.html
@@ -16,7 +16,7 @@
   </button>
   <nav class="main-nav" id="site-menu">
     <div class="nav-item nav-item--browse">
-      <a class="nav-link nav-link--browse" href="products.html" aria-haspopup="true" aria-expanded="false">Browse Life Harmony Apps/Tools</a>
+      <a class="nav-link nav-link--browse" href="products.html" aria-haspopup="true" aria-expanded="false">Discover Life Harmony Apps/Templates</a>
       <div class="nav-mega" role="menu" aria-label="Life Harmony categories">
         <div class="nav-mega__content" data-nav-mega-content>
           <p class="nav-mega__placeholder">Loading Life Harmony areas…</p>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
   </button>
   <nav class="main-nav" id="site-menu">
     <div class="nav-item nav-item--browse">
-      <a class="nav-link nav-link--browse" href="products.html" aria-haspopup="true" aria-expanded="false">Browse Life Harmony Apps/Tools</a>
+      <a class="nav-link nav-link--browse" href="products.html" aria-haspopup="true" aria-expanded="false">Discover Life Harmony Apps/Templates</a>
       <div class="nav-mega" role="menu" aria-label="Life Harmony categories">
         <div class="nav-mega__content" data-nav-mega-content>
           <p class="nav-mega__placeholder">Loading Life Harmony areas…</p>

--- a/policies.html
+++ b/policies.html
@@ -16,7 +16,7 @@
   </button>
   <nav class="main-nav" id="site-menu">
     <div class="nav-item nav-item--browse">
-      <a class="nav-link nav-link--browse" href="products.html" aria-haspopup="true" aria-expanded="false">Browse Life Harmony Apps/Tools</a>
+      <a class="nav-link nav-link--browse" href="products.html" aria-haspopup="true" aria-expanded="false">Discover Life Harmony Apps/Templates</a>
       <div class="nav-mega" role="menu" aria-label="Life Harmony categories">
         <div class="nav-mega__content" data-nav-mega-content>
           <p class="nav-mega__placeholder">Loading Life Harmony areas…</p>

--- a/product.html
+++ b/product.html
@@ -17,7 +17,7 @@
     </button>
     <nav class="main-nav" id="site-menu">
       <div class="nav-item nav-item--browse">
-        <a class="nav-link nav-link--browse" href="products.html" aria-haspopup="true" aria-expanded="false">Browse Life Harmony Apps/Tools</a>
+        <a class="nav-link nav-link--browse" href="products.html" aria-haspopup="true" aria-expanded="false">Discover Life Harmony Apps/Templates</a>
         <div class="nav-mega" role="menu" aria-label="Life Harmony categories">
           <div class="nav-mega__content" data-nav-mega-content>
             <p class="nav-mega__placeholder">Loading Life Harmony areas…</p>

--- a/products.html
+++ b/products.html
@@ -16,7 +16,7 @@
     </button>
   <nav class="main-nav" id="site-menu">
     <div class="nav-item nav-item--browse">
-      <a class="nav-link nav-link--browse" href="products.html" aria-haspopup="true" aria-expanded="false">Browse Life Harmony Apps/Tools</a>
+      <a class="nav-link nav-link--browse" href="products.html" aria-haspopup="true" aria-expanded="false">Discover Life Harmony Apps/Templates</a>
       <div class="nav-mega" role="menu" aria-label="Life Harmony categories">
         <div class="nav-mega__content" data-nav-mega-content>
           <p class="nav-mega__placeholder">Loading Life Harmony areas…</p>

--- a/style.css
+++ b/style.css
@@ -37,17 +37,16 @@ button.nav-link{border:0;background:transparent;cursor:pointer;font:inherit}
 .nav-item--browse:hover .nav-mega,.nav-item--browse:focus-within .nav-mega,.nav-item--browse.is-open .nav-mega{opacity:1;transform:translate3d(calc(-50% + var(--mega-adjust,0px)),0,0);pointer-events:auto;visibility:visible}
 .nav-mega__content{display:grid;gap:24px}
 .nav-mega__grid{display:grid;gap:18px;grid-template-columns:repeat(4,minmax(0,1fr));max-width:960px;margin:0 auto}
-.nav-mega__group{border-radius:18px;padding:20px;background:linear-gradient(150deg,var(--area-soft,#eef2ff) 0%,#fff 100%);border:1px solid var(--area-border,rgba(148,163,184,.2));box-shadow:0 18px 36px rgba(15,23,42,.08);display:flex;flex-direction:column;gap:14px;min-height:210px}
-.nav-mega__heading{display:flex;align-items:center;justify-content:space-between;gap:8px;flex-wrap:wrap}
-.nav-mega__badge{display:inline-flex;align-items:center;gap:4px;padding:4px 10px;border-radius:999px;background:var(--area-color,#6366f1);color:#fff;font-size:.75rem;font-weight:600;box-shadow:0 8px 18px var(--area-border,rgba(99,102,241,.2))}
-.nav-mega__label{font-size:1rem;font-weight:600;color:#0f172a}
+.nav-mega__group{border-radius:18px;padding:20px;background:linear-gradient(150deg,var(--area-soft,#eef2ff) 0%,#fff 100%);border:1px solid var(--area-border,rgba(148,163,184,.2));box-shadow:0 18px 36px rgba(15,23,42,.08);display:flex;flex-direction:column;gap:14px;min-height:210px;color:#0f172a;text-decoration:none;transition:transform .2s ease,box-shadow .2s ease,border-color .2s ease}
+.nav-mega__group:hover,.nav-mega__group:focus-visible{transform:translateY(-4px);box-shadow:0 24px 48px rgba(15,23,42,.16);border-color:var(--area-color,#6366f1)}
+.nav-mega__group:focus-visible{outline:none}
+.nav-mega__heading{display:flex;align-items:center;justify-content:center;gap:8px;flex-wrap:wrap;text-align:center}
+.nav-mega__badge{display:inline-flex;align-items:center;justify-content:center;gap:6px;padding:6px 16px;border-radius:999px;background:var(--area-color,#6366f1);color:#fff;font-size:.82rem;font-weight:600;line-height:1.3;box-shadow:0 8px 18px var(--area-border,rgba(99,102,241,.2));white-space:normal;max-width:100%}
 .nav-mega__question{margin:0;font-size:.95rem;font-weight:500;color:var(--area-ink,var(--area-color,#475569));line-height:1.4}
 .nav-mega__products{list-style:none;margin:0;padding:0;display:grid;gap:8px}
-.nav-mega__products li{display:flex;align-items:flex-start;gap:10px;padding:9px 12px;border-radius:12px;background:rgba(255,255,255,.9);border:1px solid rgba(148,163,184,.22);color:#1f2937;font-size:.92rem;font-weight:500;line-height:1.35;box-shadow:0 10px 24px rgba(15,23,42,.06)}
+.nav-mega__products li{display:flex;align-items:flex-start;gap:10px;padding:9px 12px;border-radius:12px;background:transparent;border:1px solid rgba(148,163,184,.18);color:#1f2937;font-size:.92rem;font-weight:500;line-height:1.35}
 .nav-mega__products li::before{content:"•";color:var(--area-ink,var(--area-color,#6366f1));font-size:.95rem;line-height:1;transform:translateY(2px)}
 .nav-mega__empty{color:#64748b;font-size:.9rem;padding:4px 0}
-.nav-mega__area-link{margin-top:auto;align-self:flex-start;font-weight:600;font-size:.92rem;color:var(--area-color,#4338ca);display:inline-flex;align-items:center;gap:6px}
-.nav-mega__area-link::after{content:"→"}
 .nav-mega__placeholder{margin:0;color:#475569}
 .nav-mega__footer{display:flex;justify-content:center;padding-top:12px;border-top:1px solid rgba(148,163,184,.2)}
 .nav-mega__footer a{font-weight:600;color:#1d4ed8}


### PR DESCRIPTION
## Summary
- retitle the "Browse" navigation button copy to "Discover Life Harmony Apps/Templates"
- center the browse mega menu and render each category as a single clickable card with the full title pill
- refresh mega menu styling by removing duplicate headings, adding hover focus states, and making highlight pills transparent

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68d0202c2ab0832d84931080e0b4cbac