### PR TITLE
Adjust navigation highlight styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -22,11 +22,11 @@ img{max-width:100%;display:block}
 .site-header{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:14px 20px;border-bottom:1px solid var(--border);position:sticky;top:0;background:rgba(255,255,255,.96);backdrop-filter:saturate(150%) blur(14px);z-index:60}
 .brand{display:inline-flex;align-items:center;gap:8px;font-weight:700;font-size:1.12rem;letter-spacing:.02em;color:#0f172a;text-decoration:none;transition:color .2s ease}
 .brand:hover,.brand:focus-visible{color:#1d4ed8}
-.main-nav{display:flex;align-items:center;gap:10px;padding:6px 8px;border-radius:999px;background:rgba(244,246,255,.72);border:1px solid rgba(148,163,184,.24);box-shadow:0 12px 30px rgba(15,23,42,.08);position:relative}
+.main-nav{display:flex;align-items:center;gap:10px;padding:6px 8px;border-radius:999px;background:rgba(255,255,255,.78);border:1px solid rgba(148,163,184,.22);box-shadow:0 12px 30px rgba(15,23,42,.08);position:relative}
 .nav-item{position:relative}
-.nav-link{display:inline-flex;align-items:center;gap:8px;padding:10px 14px;border-radius:12px;font-weight:600;color:var(--nav-link-ink);background:transparent;transition:background .2s ease,color .2s ease,box-shadow .2s ease}
-.nav-link:hover,.nav-link:focus-visible{background:rgba(255,255,255,.95);box-shadow:0 10px 20px rgba(15,23,42,.08);color:var(--nav-link-ink-strong)}
-.nav-link.active{background:#1d4ed8;color:#fff;box-shadow:0 12px 26px rgba(37,99,235,.26)}
+.nav-link{display:inline-flex;align-items:center;gap:8px;padding:10px 14px;border-radius:12px;font-weight:600;color:var(--nav-link-ink);background:transparent;border:1px solid transparent;transition:background .2s ease,color .2s ease,box-shadow .2s ease,border-color .2s ease}
+.nav-link:hover,.nav-link:focus-visible{background:rgba(255,255,255,.95);box-shadow:0 10px 20px rgba(15,23,42,.08);color:var(--nav-link-ink-strong);border-color:rgba(148,163,184,.32)}
+.nav-link.active{background:rgba(255,255,255,.95);color:var(--nav-link-ink-strong);border-color:#1d4ed8;box-shadow:0 12px 26px rgba(37,99,235,.18)}
 .nav-link--icon{position:relative;padding-right:20px}
 .nav-link--icon.has-items{color:#1d4ed8}
 button.nav-link{border:0;background:transparent;cursor:pointer;font:inherit}
@@ -125,10 +125,10 @@ body[class*="theme-midnight"]{
     --nav-link-ink-strong:#fff;
   }
 
-  .main-nav{background:rgba(15,23,42,.85);border-color:rgba(148,163,184,.4);box-shadow:0 12px 30px rgba(15,23,42,.45);}
+  .main-nav{background:rgba(255,255,255,.85);border-color:rgba(148,163,184,.3);box-shadow:0 12px 30px rgba(15,23,42,.25);}
 
   .nav-link:hover,
-  .nav-link:focus-visible{background:rgba(148,163,184,.2);box-shadow:0 12px 26px rgba(15,23,42,.45);}
+  .nav-link:focus-visible{background:rgba(255,255,255,.95);box-shadow:0 12px 26px rgba(15,23,42,.2);border-color:rgba(148,163,184,.35);}
 }
 
 @media(max-width:1040px){
@@ -219,8 +219,8 @@ body[class*="theme-midnight"]{
   .main-nav>*+*{margin-top:6px}
   .nav-item{width:100%}
   .nav-link{width:100%;justify-content:space-between;background:#f8f9ff;border:1px solid transparent;box-shadow:none}
-  .nav-link:hover,.nav-link:focus-visible{background:#e0e7ff;box-shadow:none}
-  .nav-link.active{background:#dbeafe;color:#1d4ed8}
+  .nav-link:hover,.nav-link:focus-visible{background:#e0e7ff;box-shadow:none;border-color:#c7d2fe}
+  .nav-link.active{background:#fff;color:var(--nav-link-ink-strong);border-color:#1d4ed8}
   .nav-item--browse .nav-link--browse::after{transform:none}
   .nav-item--browse .nav-mega{display:none!important;pointer-events:none!important;visibility:hidden!important}
   .nav-item--bundles .nav-link--bundles::after{transform:none}
@@ -300,7 +300,7 @@ body[class*="theme-midnight"]{
 .site-footer__grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(180px,1fr));gap:28px}
 .site-footer__heading{margin:0 0 14px;font-size:1rem;font-weight:600;color:#0f172a;letter-spacing:.01em}
 .site-footer__links{list-style:none;margin:0;padding:0;display:grid;gap:10px}
-.site-footer__links a{text-decoration:none;font-weight:500;color:#1f2937;transition:color .2s ease,text-decoration .2s ease}
+.site-footer__links a{text-decoration:none;font-weight:400;color:#1f2937;transition:color .2s ease,text-decoration .2s ease}
 .site-footer__links a:hover,.site-footer__links a:focus-visible{color:#1d4ed8;text-decoration:underline}
 .site-footer__column--newsletter{display:grid;gap:14px}
 .footer-form{display:grid;gap:10px}


### PR DESCRIPTION
## Summary
- lighten the main navigation background and switch the active link treatment to a bordered highlight
- mirror the bordered highlight behavior for hover and mobile navigation states, including dark mode
- reduce footer link font weight so links are visually distinct from headings

## Testing
- no automated tests were run (CSS-only change)


------
https://chatgpt.com/codex/tasks/task_e_68d2c14c6954832db1e6618ea16fc7a7