### PR TITLE
Revamp navigation mega menu

### DIFF
--- a/app.js
+++ b/app.js
@@ -250,6 +250,74 @@ App.LIFE_AREAS = {
   }
 };
 
+App.NAV_PRODUCT_META = {
+  pomodoro: {
+    type: "Focus System",
+    format: "Web App + Sheets",
+    badge: "New"
+  },
+  "budget-dashboard": {
+    type: "Finance Dashboard",
+    format: "Sheets",
+    badge: "Best-Seller"
+  },
+  "pomodoro-pro": {
+    type: "Focus System",
+    format: "Web App + Sheets",
+    badge: "Popular"
+  }
+};
+
+App.NAV_AREA_EXTRAS = {
+  love: [
+    { id: "love-couples-connection", name: "Couples Connection Journal", type: "Journal", format: "PDF", badge: "Popular", price: 19 },
+    { id: "love-daily-ritual", name: "Daily Ritual Prompts", type: "Cards", format: "Printable", badge: "", price: 12 },
+    { id: "love-memory-keeper", name: "Shared Memory Keeper", type: "Template", format: "Sheets", badge: "Best-Seller", price: 24 },
+    { id: "love-date-night", name: "Date Night Generator", type: "Tool", format: "Web App", badge: "New", price: 9 },
+    { id: "love-goals", name: "Love Goals Planner", type: "Planner", format: "Sheets", badge: "", price: 14 }
+  ],
+  career: [
+    { id: "career-skill-tracker", name: "Skill Tracker Pro", type: "Tracker", format: "Sheets", badge: "", price: 18 },
+    { id: "career-milestone", name: "Milestone Planner", type: "Planner", format: "Sheets", badge: "", price: 16 },
+    { id: "career-reflection", name: "Weekly Reflection Guide", type: "Guide", format: "PDF", badge: "New", price: 11 },
+    { id: "career-portfolio", name: "Portfolio Projects Board", type: "Board", format: "Sheets", badge: "", price: 15 },
+    { id: "career-sprints", name: "Learning Sprints", type: "System", format: "Notion", badge: "", price: 17 }
+  ],
+  health: [
+    { id: "health-habit-loop", name: "Habit Loop Tracker", type: "Tracker", format: "Sheets", badge: "", price: 14 },
+    { id: "health-meal-movement", name: "Meal & Movement Planner", type: "Planner", format: "Sheets", badge: "Popular", price: 19 },
+    { id: "health-recovery", name: "Recovery Journal", type: "Journal", format: "PDF", badge: "", price: 9 },
+    { id: "health-sleep", name: "Sleep Routine Builder", type: "Template", format: "Sheets", badge: "", price: 12 }
+  ],
+  finances: [
+    { id: "finance-budget", name: "Budget Blueprint", type: "Budget", format: "Sheets", badge: "Best-Seller", price: 29 },
+    { id: "finance-cashflow", name: "Cash-Flow Dashboard", type: "Dashboard", format: "Sheets", badge: "", price: 24 },
+    { id: "finance-savings", name: "Savings Scorecard", type: "Tracker", format: "Sheets", badge: "", price: 12 },
+    { id: "finance-debt", name: "Debt Snowball Coach", type: "Template", format: "Sheets", badge: "", price: 15 },
+    { id: "finance-investing", name: "Investing Starter Pack", type: "Guide", format: "PDF", badge: "", price: 19 }
+  ],
+  fun: [
+    { id: "fun-weekend", name: "Weekend Adventure Planner", type: "Planner", format: "PDF", badge: "", price: 9 },
+    { id: "fun-hobby", name: "Creative Hobby Dashboard", type: "Dashboard", format: "Sheets", badge: "", price: 12 },
+    { id: "fun-bucket", name: "Bucket List Builder", type: "Template", format: "Sheets", badge: "", price: 8 }
+  ],
+  family: [
+    { id: "family-agenda", name: "Shared Family Agenda", type: "Planner", format: "Sheets", badge: "", price: 12 },
+    { id: "family-celebration", name: "Celebration Planner", type: "Planner", format: "PDF", badge: "", price: 8 },
+    { id: "family-rituals", name: "Connection Rituals", type: "Ideas", format: "PDF", badge: "", price: 6 }
+  ],
+  environment: [
+    { id: "environment-room-reset", name: "Room Reset Routine", type: "Checklist", format: "PDF", badge: "", price: 6 },
+    { id: "environment-declutter", name: "Seasonal Declutter List", type: "Checklist", format: "PDF", badge: "", price: 7 },
+    { id: "environment-home-project", name: "Home Project Planner", type: "Planner", format: "Sheets", badge: "", price: 13 }
+  ],
+  spirituality: [
+    { id: "spirit-reflection", name: "Mindful Reflection Journal", type: "Journal", format: "PDF", badge: "", price: 9 },
+    { id: "spirit-service", name: "Community Service Tracker", type: "Tracker", format: "Sheets", badge: "", price: 7 },
+    { id: "spirit-gratitude", name: "Gratitude & Intention Log", type: "Journal", format: "PDF", badge: "", price: 6 }
+  ]
+};
+
 /*****************************************************
  * Utils
  *****************************************************/
@@ -816,51 +884,441 @@ App.initNavDropdown = function() {
     close();
   });
 
-  const render = () => {
-    const groups = Object.entries(App.LIFE_AREAS)
-      .map(([, info]) => {
-        const highlights = Array.isArray(info.menuHighlights) ? info.menuHighlights : [];
-        const highlightMarkup = highlights.length
-          ? highlights.map(item => `<li>${App.escapeHtml(item)}</li>`).join("")
-          : '<li class="nav-mega__empty">Fresh tools coming soon</li>';
-        const questionMarkup = info.menuQuestion
-          ? `<p class="nav-mega__question">${App.escapeHtml(info.menuQuestion)}</p>`
-          : "";
-        const soft = App.hexToRgba(info.color, 0.12);
-        const border = App.hexToRgba(info.color, 0.24);
-        const ink = App.hexToRgba(info.color, 0.7);
-        const title = App.escapeHtml(info.title || "");
-        const link = App.escapeHtml(info.link || "#");
-        const color = App.escapeHtml(info.color || "");
-        const softColor = App.escapeHtml(soft);
-        const borderColor = App.escapeHtml(border);
-        const inkColor = App.escapeHtml(ink);
+
+  const areaOrder = Object.keys(App.LIFE_AREAS || {});
+  if (!areaOrder.length) {
+    content.innerHTML = '<p class="nav-mega__placeholder">Life Harmony tools are coming soon.</p>';
+    App.loadProducts().catch(err => {
+      console.warn("Unable to preload products:", err);
+    });
+    return;
+  }
+
+  const navAccentMap = {
+    love: "#ef5da8",
+    career: "#7c5cff",
+    health: "#22c55e",
+    finances: "#d97706",
+    fun: "#f59e0b",
+    family: "#60a5fa",
+    environment: "#10b981",
+    spirituality: "#8b5cf6"
+  };
+
+  const navState = {
+    cat: areaOrder[0],
+    q: "",
+    sort: "name",
+    page: 1,
+    pageSize: 6,
+    tinted: true
+  };
+
+  const formatPriceDisplay = value => {
+    if (typeof value === "string") {
+      const trimmed = value.trim();
+      return trimmed ? (trimmed.startsWith("$") ? trimmed : `$${trimmed}`) : "";
+    }
+    const number = Number(value);
+    if (!Number.isFinite(number)) return "";
+    return number % 1 === 0 ? `$${number.toFixed(0)}` : `$${number.toFixed(2)}`;
+  };
+
+  const normalizeEntry = (areaId, item = {}, index = 0) => {
+    const fallbackId = `${areaId || "area"}-item-${index}`;
+    const id = item.id || fallbackId;
+    const name = item.name || "Harmony Sheets tool";
+    const type = item.type || "Template";
+    const format = item.format || "Sheets";
+    const badge = item.badge || "";
+    const tagline = item.tagline || "";
+    const explicitDisplay = typeof item.priceDisplay === "string" ? item.priceDisplay : "";
+    const computedDisplay =
+      explicitDisplay ||
+      (typeof item.price === "number"
+        ? formatPriceDisplay(item.price)
+        : typeof item.price === "string"
+        ? item.price
+        : "");
+    const priceDisplay = computedDisplay ? formatPriceDisplay(computedDisplay) : "";
+    let priceValue = Number.isFinite(item.priceValue) ? item.priceValue : null;
+    if (priceValue === null) {
+      if (typeof item.price === "number" && Number.isFinite(item.price)) {
+        priceValue = item.price;
+      } else {
+        priceValue = App.parsePrice(priceDisplay);
+      }
+    }
+    if (!Number.isFinite(priceValue)) priceValue = Number.POSITIVE_INFINITY;
+    const href =
+      item.url ||
+      (item.id && typeof item.id === "string" && item.id.startsWith("http")
+        ? item.id
+        : `products.html?area=${encodeURIComponent(areaId)}`);
+    return {
+      id,
+      name,
+      type,
+      format,
+      badge,
+      tagline,
+      priceDisplay,
+      priceValue,
+      url: href
+    };
+  };
+
+  const buildAreaProducts = rawProducts => {
+    const map = {};
+    areaOrder.forEach(id => {
+      map[id] = [];
+    });
+
+    const extras = App.NAV_AREA_EXTRAS || {};
+    Object.entries(extras).forEach(([areaId, items]) => {
+      if (!Array.isArray(items) || !items.length) return;
+      if (!map[areaId]) map[areaId] = [];
+      items.forEach((item, index) => {
+        map[areaId].push(normalizeEntry(areaId, item, index));
+      });
+    });
+
+    if (Array.isArray(rawProducts)) {
+      rawProducts.forEach(product => {
+        if (!product) return;
+        const areas = Array.isArray(product.lifeAreas) ? product.lifeAreas : [];
+        if (!areas.length) return;
+        const meta = (App.NAV_PRODUCT_META && App.NAV_PRODUCT_META[product.id]) || {};
+        const base = {
+          id: product.id,
+          name: product.name,
+          type: meta.type,
+          format: meta.format,
+          badge: meta.badge,
+          priceDisplay: meta.priceDisplay || product.price,
+          priceValue: meta.priceValue,
+          price: meta.price,
+          url: meta.url || `product.html?id=${encodeURIComponent(product.id)}`,
+          tagline: product.tagline
+        };
+        const areaOverrides = meta.areas || {};
+        areas.forEach(areaId => {
+          if (!map[areaId]) map[areaId] = [];
+          const override = areaOverrides[areaId] || {};
+          map[areaId].push(normalizeEntry(areaId, { ...base, ...override }, map[areaId].length));
+        });
+      });
+    }
+
+    Object.keys(map).forEach(areaId => {
+      const seen = new Set();
+      map[areaId] = map[areaId].filter(entry => {
+        const key = entry.id || `${entry.name}-${entry.type}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      });
+    });
+
+    return map;
+  };
+
+  let areaProducts = buildAreaProducts([]);
+  let panelEl = null;
+  const catButtonMap = new Map();
+  let pillEl = null;
+  let rowsEl = null;
+  let infoTextEl = null;
+  let prevBtn = null;
+  let nextBtn = null;
+  let searchInput = null;
+  let sortSelect = null;
+  let modeBtn = null;
+
+  const updateCounts = () => {
+    catButtonMap.forEach(({ count }, id) => {
+      if (!count) return;
+      const total = Array.isArray(areaProducts[id]) ? areaProducts[id].length : 0;
+      count.textContent = total;
+    });
+  };
+
+  const badgeWeight = badge => {
+    const value = String(badge || "").toLowerCase();
+    if (!value) return 0;
+    if (value.includes("best")) return 3;
+    if (value.includes("popular")) return 2;
+    if (value.includes("new")) return 1;
+    return 0;
+  };
+
+  const getBadgeType = badge => {
+    const value = String(badge || "").toLowerCase();
+    if (!value) return "";
+    if (value.includes("best")) return "bestseller";
+    if (value.includes("popular")) return "popular";
+    if (value.includes("new")) return "new";
+    return "";
+  };
+
+  const updateActive = () => {
+    if (!panelEl) return;
+    if (!areaOrder.includes(navState.cat)) {
+      navState.cat = areaOrder[0];
+    }
+
+    const info = App.LIFE_AREAS[navState.cat] || {};
+    const accent = navAccentMap[navState.cat] || info.color || "#7c5cff";
+    panelEl.dataset.area = navState.cat;
+    panelEl.style.setProperty("--nav-mega-acc", accent);
+    panelEl.classList.toggle("is-tinted", Boolean(navState.tinted));
+
+    const safeCatClass = navState.cat.replace(/[^a-z0-9-]/g, "");
+    if (pillEl) {
+      pillEl.textContent = info.title || "Life Harmony";
+      pillEl.className = `nav-mega__pill nav-mega__pill--${safeCatClass}`;
+    }
+
+    if (modeBtn) {
+      modeBtn.setAttribute("aria-pressed", navState.tinted ? "true" : "false");
+      modeBtn.textContent = `Color mode: ${navState.tinted ? "On" : "Off"}`;
+    }
+
+    if (searchInput && searchInput.value !== navState.q) {
+      searchInput.value = navState.q;
+    }
+
+    if (sortSelect && sortSelect.value !== navState.sort) {
+      sortSelect.value = navState.sort;
+    }
+
+    catButtonMap.forEach(({ button }, id) => {
+      if (!button) return;
+      const isActive = id === navState.cat;
+      button.setAttribute("aria-current", isActive ? "true" : "false");
+    });
+
+    const baseItems = Array.isArray(areaProducts[navState.cat]) ? areaProducts[navState.cat] : [];
+    const query = (navState.q || "").trim().toLowerCase();
+
+    let filtered = baseItems;
+    if (query) {
+      filtered = baseItems.filter(item => {
+        return [item.name, item.type, item.format, item.badge, item.tagline, item.priceDisplay]
+          .some(value => String(value || "").toLowerCase().includes(query));
+      });
+    }
+
+    const sorted = filtered.slice().sort((a, b) => {
+      if (navState.sort === "price") {
+        return a.priceValue - b.priceValue;
+      }
+      if (navState.sort === "badge") {
+        const diff = badgeWeight(b.badge) - badgeWeight(a.badge);
+        return diff !== 0 ? diff : a.name.localeCompare(b.name);
+      }
+      return a.name.localeCompare(b.name);
+    });
+
+    const totalItems = sorted.length;
+    const totalPages = Math.max(1, Math.ceil(totalItems / navState.pageSize));
+    if (!Number.isFinite(navState.page) || navState.page < 1) navState.page = 1;
+    if (navState.page > totalPages) navState.page = totalPages;
+    const start = (navState.page - 1) * navState.pageSize;
+    const pageItems = sorted.slice(start, start + navState.pageSize);
+
+    if (rowsEl) {
+      if (!totalItems) {
+        const message = query
+          ? `No matches for “${navState.q}”.`
+          : info.empty || "Fresh tools coming soon.";
+        rowsEl.innerHTML = `<tr class="nav-mega__empty-row"><td colspan="5">${App.escapeHtml(message)}</td></tr>`;
+      } else {
+        const rows = pageItems
+          .map(item => {
+            const badgeType = getBadgeType(item.badge);
+            const badgeMarkup = item.badge
+              ? `<span class="nav-mega__tbadge"${badgeType ? ` data-type="${badgeType}"` : ""}>${App.escapeHtml(item.badge)}</span>`
+              : "";
+            const priceText = item.priceDisplay ? App.escapeHtml(item.priceDisplay) : "—";
+            const tagline = item.tagline ? `<div class="nav-mega__product-sub">${App.escapeHtml(item.tagline)}</div>` : "";
+            const url = App.escapeHtml(item.url || `products.html?area=${encodeURIComponent(navState.cat)}`);
+            const name = App.escapeHtml(item.name || "Harmony Sheets tool");
+            const type = App.escapeHtml(item.type || "Template");
+            const format = App.escapeHtml(item.format || "Sheets");
+            return `<tr><td><a class="nav-mega__product-link" href="${url}">${name}</a>${tagline}</td><td>${type}</td><td>${format}</td><td>${badgeMarkup}</td><td class="nav-mega__price">${priceText}</td></tr>`;
+          })
+          .join("");
+        rowsEl.innerHTML = rows;
+      }
+    }
+
+    if (infoTextEl) {
+      if (!totalItems) {
+        infoTextEl.textContent = query ? `No matches for “${navState.q}”` : "More tools coming soon";
+      } else {
+        infoTextEl.textContent = `${totalItems} ${totalItems === 1 ? "tool" : "tools"} • Page ${navState.page}/${totalPages}`;
+      }
+    }
+
+    if (prevBtn) prevBtn.disabled = navState.page <= 1 || totalItems === 0;
+    if (nextBtn) nextBtn.disabled = navState.page >= totalPages || totalItems === 0;
+
+    scheduleReposition();
+  };
+
+  const pillId = `nav-mega-pill-${Math.random().toString(36).slice(2, 8)}`;
+  const renderShell = () => {
+    const catItems = areaOrder
+      .map(id => {
+        const info = App.LIFE_AREAS[id];
+        if (!info) return "";
+        const label = App.escapeHtml(info.short || info.title || id);
+        const safeId = App.escapeHtml(id);
+        const count = Array.isArray(areaProducts[id]) ? areaProducts[id].length : 0;
         return `
-          <a class="nav-mega__group" role="menuitem" href="${link}" style="--area-color:${color};--area-soft:${softColor};--area-border:${borderColor};--area-ink:${inkColor};">
-            <header class="nav-mega__heading">
-              <span class="nav-mega__badge">${title}</span>
-            </header>
-            ${questionMarkup}
-            <ul class="nav-mega__products">${highlightMarkup}</ul>
-          </a>
+          <li>
+            <button class="nav-mega__catbtn" type="button" data-nav-cat="${safeId}" aria-current="${id === navState.cat}">
+              <span class="nav-mega__dot nav-mega__dot--${safeId}"></span>
+              <span class="nav-mega__catname">${label}</span>
+              <span class="nav-mega__count" data-nav-count>${count}</span>
+            </button>
+          </li>
         `;
       })
       .join("");
 
     content.innerHTML = `
-      <div class="nav-mega__grid">
-        ${groups}
+      <div class="nav-mega__panel is-tinted" data-nav-panel data-area="${App.escapeHtml(navState.cat)}">
+        <div class="nav-mega__pane">
+          <aside class="nav-mega__cats">
+            <div class="nav-mega__cats-head">Explore</div>
+            <ul class="nav-mega__catlist">
+              ${catItems}
+            </ul>
+          </aside>
+          <div class="nav-mega__prod">
+            <div class="nav-mega__prod-head">
+              <span class="nav-mega__pill nav-mega__pill--${App.escapeHtml(navState.cat)}" id="${pillId}" data-nav-pill>${App.escapeHtml(App.LIFE_AREAS[navState.cat]?.title || "Life Harmony")}</span>
+              <div class="nav-mega__tools">
+                <label class="nav-mega__search">
+                  <span class="sr-only">Search Life Harmony tools</span>
+                  <input type="search" placeholder="Search tools…" value="${App.escapeHtml(navState.q)}" data-nav-search>
+                </label>
+                <select class="nav-mega__select" data-nav-sort>
+                  <option value="name"${navState.sort === "name" ? " selected" : ""}>Sort: Name</option>
+                  <option value="price"${navState.sort === "price" ? " selected" : ""}>Sort: Price</option>
+                  <option value="badge"${navState.sort === "badge" ? " selected" : ""}>Sort: Badge</option>
+                </select>
+                <button class="nav-mega__modebtn" type="button" data-nav-mode aria-pressed="${navState.tinted ? "true" : "false"}">Color mode: ${navState.tinted ? "On" : "Off"}</button>
+              </div>
+            </div>
+            <div class="nav-mega__scroll">
+              <table class="nav-mega__table" aria-describedby="${pillId}">
+                <thead>
+                  <tr>
+                    <th scope="col" style="width:40%">Product</th>
+                    <th scope="col" style="width:18%">Type</th>
+                    <th scope="col" style="width:18%">Format</th>
+                    <th scope="col" style="width:10%">Badge</th>
+                    <th scope="col" style="width:14%">Price</th>
+                  </tr>
+                </thead>
+                <tbody data-nav-rows>
+                  <tr class="nav-mega__empty-row"><td colspan="5">Loading Life Harmony tools…</td></tr>
+                </tbody>
+              </table>
+            </div>
+            <div class="nav-mega__pager">
+              <div class="nav-mega__pager-info">
+                <span data-nav-info>Loading…</span>
+                <a href="products.html">Browse all Harmony tools</a>
+              </div>
+              <button type="button" data-nav-prev disabled>‹ Prev</button>
+              <button type="button" data-nav-next disabled>Next ›</button>
+            </div>
+          </div>
+        </div>
       </div>
-      <div class="nav-mega__footer"><a href="products.html">Browse all Harmony tools</a></div>
     `;
+
+    panelEl = content.querySelector("[data-nav-panel]");
+    pillEl = content.querySelector("[data-nav-pill]");
+    rowsEl = content.querySelector("[data-nav-rows]");
+    infoTextEl = content.querySelector("[data-nav-info]");
+    prevBtn = content.querySelector("[data-nav-prev]");
+    nextBtn = content.querySelector("[data-nav-next]");
+    searchInput = content.querySelector("[data-nav-search]");
+    sortSelect = content.querySelector("[data-nav-sort]");
+    modeBtn = content.querySelector("[data-nav-mode]");
+
+    catButtonMap.clear();
+    content.querySelectorAll("[data-nav-cat]").forEach(btn => {
+      const id = btn.getAttribute("data-nav-cat");
+      const count = btn.querySelector("[data-nav-count]");
+      catButtonMap.set(id, { button: btn, count });
+      btn.addEventListener("click", () => {
+        if (navState.cat === id) return;
+        navState.cat = id;
+        navState.page = 1;
+        updateActive();
+      });
+    });
+
+    if (searchInput) {
+      searchInput.addEventListener("input", event => {
+        navState.q = event.target.value || "";
+        navState.page = 1;
+        updateActive();
+      });
+    }
+
+    if (sortSelect) {
+      sortSelect.addEventListener("change", event => {
+        navState.sort = event.target.value || "name";
+        updateActive();
+      });
+    }
+
+    if (modeBtn) {
+      modeBtn.addEventListener("click", () => {
+        navState.tinted = !navState.tinted;
+        updateActive();
+      });
+    }
+
+    if (prevBtn) {
+      prevBtn.addEventListener("click", () => {
+        if (navState.page > 1) {
+          navState.page -= 1;
+          updateActive();
+        }
+      });
+    }
+
+    if (nextBtn) {
+      nextBtn.addEventListener("click", () => {
+        navState.page += 1;
+        updateActive();
+      });
+    }
+
     scheduleReposition();
   };
 
-  render();
+  renderShell();
+  updateCounts();
+  updateActive();
 
-  App.loadProducts().catch(err => {
-    console.warn("Unable to preload products:", err);
-  });
+  App.loadProducts()
+    .then(products => {
+      areaProducts = buildAreaProducts(products);
+      updateCounts();
+      updateActive();
+    })
+    .catch(err => {
+      console.warn("Unable to preload products:", err);
+    });
 
   const bundleItem = App.qs(".nav-item--bundles");
   const bundleLink = bundleItem?.querySelector(".nav-link--bundles");

--- a/style.css
+++ b/style.css
@@ -35,24 +35,77 @@ button.nav-link{border:0;background:transparent;cursor:pointer;font:inherit}
 .nav-link--icon .cart-count.is-visible{opacity:1;transform:translateY(-6px) scale(1)}
 .nav-link--browse::after{content:"▾";font-size:.68em;margin-left:6px;transition:transform .2s ease}
 .nav-item--browse.is-open>.nav-link--browse::after,.nav-item--browse:hover>.nav-link--browse::after{transform:rotate(180deg)}
-.nav-item--browse .nav-mega{position:absolute;top:calc(100% + 14px);left:50%;width:min(1040px,calc(100vw - 48px));background:rgba(255,255,255,.98);border-radius:22px;border:1px solid rgba(148,163,184,.26);box-shadow:0 32px 68px rgba(15,23,42,.18);padding:28px;opacity:0;--mega-adjust:0px;transform:translate3d(calc(-50% + var(--mega-adjust,0px)),10px,0);pointer-events:none;visibility:hidden;transition:opacity .2s ease,transform .2s ease,visibility .2s ease;z-index:70}
+.nav-item--browse .nav-mega{position:absolute;top:calc(100% + 14px);left:50%;width:min(1120px,calc(100vw - 48px));background:rgba(255,255,255,.98);border-radius:24px;border:1px solid rgba(148,163,184,.26);box-shadow:0 32px 68px rgba(15,23,42,.18);padding:24px;opacity:0;--mega-adjust:0px;transform:translate3d(calc(-50% + var(--mega-adjust,0px)),10px,0);pointer-events:none;visibility:hidden;transition:opacity .2s ease,transform .2s ease,visibility .2s ease;z-index:70}
 .nav-item--browse .nav-mega::before,.nav-item--bundles .nav-flyout::before{content:"";position:absolute;left:0;right:0;top:-14px;height:14px}
 .nav-item--browse:hover .nav-mega,.nav-item--browse:focus-within .nav-mega,.nav-item--browse.is-open .nav-mega{opacity:1;transform:translate3d(calc(-50% + var(--mega-adjust,0px)),0,0);pointer-events:auto;visibility:visible}
-.nav-mega__content{display:grid;gap:24px}
-.nav-mega__grid{display:grid;gap:18px;grid-template-columns:repeat(4,minmax(0,1fr));max-width:960px;margin:0 auto}
-.nav-mega__group{border-radius:18px;padding:20px;background:linear-gradient(150deg,var(--area-soft,#eef2ff) 0%,#fff 100%);border:1px solid var(--area-border,rgba(148,163,184,.2));box-shadow:0 18px 36px rgba(15,23,42,.08);display:flex;flex-direction:column;gap:14px;min-height:210px;color:#0f172a;text-decoration:none;transition:transform .2s ease,box-shadow .2s ease,border-color .2s ease}
-.nav-mega__group:hover,.nav-mega__group:focus-visible{transform:translateY(-4px);box-shadow:0 24px 48px rgba(15,23,42,.16);border-color:var(--area-color,#6366f1)}
-.nav-mega__group:focus-visible{outline:none}
-.nav-mega__heading{display:flex;align-items:center;justify-content:center;gap:8px;flex-wrap:wrap;text-align:center}
-.nav-mega__badge{display:inline-flex;align-items:center;justify-content:center;gap:6px;padding:6px 16px;border-radius:999px;background:var(--area-color,#6366f1);color:#fff;font-size:.82rem;font-weight:600;line-height:1.3;box-shadow:0 8px 18px var(--area-border,rgba(99,102,241,.2));white-space:normal;max-width:100%}
-.nav-mega__question{margin:0;font-size:.95rem;font-weight:500;color:var(--area-ink,var(--area-color,#475569));line-height:1.4}
-.nav-mega__products{list-style:none;margin:0;padding:0;display:grid;gap:8px}
-.nav-mega__products li{display:flex;align-items:flex-start;gap:10px;padding:9px 12px;border-radius:12px;background:transparent;border:1px solid rgba(148,163,184,.18);color:#1f2937;font-size:.92rem;font-weight:500;line-height:1.35}
-.nav-mega__products li::before{content:"•";color:var(--area-ink,var(--area-color,#6366f1));font-size:.95rem;line-height:1;transform:translateY(2px)}
-.nav-mega__empty{color:#64748b;font-size:.9rem;padding:4px 0}
+.nav-mega__content{padding:0;display:block}
+.nav-mega__panel{--nav-mega-ink:#0f172a;--nav-mega-muted:#64748b;--nav-mega-line:#e5e7eb;--nav-mega-soft:#f8fafc;--nav-mega-bg:#ffffff;--nav-mega-acc:#7c5cff;display:grid;gap:0;background:var(--nav-mega-bg);border-radius:18px;border:1px solid var(--nav-mega-line);box-shadow:0 12px 30px rgba(2,6,23,.08);overflow:hidden}
+.nav-mega__pane{display:grid;grid-template-columns:280px minmax(0,1fr);min-height:380px}
+.nav-mega__cats{background:var(--nav-mega-soft);border-right:1px solid var(--nav-mega-line);display:flex;flex-direction:column}
+.nav-mega__cats-head{padding:14px 18px;font-weight:700;letter-spacing:.2px;color:var(--nav-mega-ink)}
+.nav-mega__catlist{list-style:none;margin:0;padding:8px;display:grid;gap:6px}
+.nav-mega__catbtn{width:100%;display:flex;align-items:center;gap:12px;border:1px solid transparent;background:transparent;color:var(--nav-mega-ink);padding:10px 12px;border-radius:12px;cursor:pointer;font:inherit;text-align:left;transition:background .2s ease,border-color .2s ease,transform .2s ease}
+.nav-mega__catbtn:hover,.nav-mega__catbtn:focus-visible{background:#fff;border-color:var(--nav-mega-line);outline:none}
+.nav-mega__catbtn[aria-current="true"]{background:#fff;border-color:var(--nav-mega-line);box-shadow:0 0 0 1px rgba(148,163,184,.2)}
+.nav-mega__dot{width:8px;height:8px;border-radius:50%;flex-shrink:0}
+.nav-mega__dot--love{background:#ef5da8}
+.nav-mega__dot--career{background:#7c5cff}
+.nav-mega__dot--health{background:#22c55e}
+.nav-mega__dot--finances{background:#d97706}
+.nav-mega__dot--fun{background:#f59e0b}
+.nav-mega__dot--family{background:#60a5fa}
+.nav-mega__dot--environment{background:#10b981}
+.nav-mega__dot--spirituality{background:#8b5cf6}
+.nav-mega__catname{font-weight:600}
+.nav-mega__count{margin-left:auto;color:var(--nav-mega-muted);font-size:.78rem}
+.nav-mega__prod{padding:16px 18px;display:flex;flex-direction:column;gap:12px}
+.nav-mega__prod-head{display:flex;align-items:center;gap:12px;flex-wrap:wrap}
+.nav-mega__pill{border:1px solid var(--nav-mega-line);padding:4px 12px;border-radius:999px;font-weight:700;font-size:.72rem;letter-spacing:.06em;text-transform:uppercase;color:var(--nav-mega-muted)}
+.nav-mega__pill--love{border-color:#ef5da8;color:#ef5da8}
+.nav-mega__pill--career{border-color:#7c5cff;color:#7c5cff}
+.nav-mega__pill--health{border-color:#22c55e;color:#22c55e}
+.nav-mega__pill--finances{border-color:#d97706;color:#d97706}
+.nav-mega__pill--fun{border-color:#f59e0b;color:#f59e0b}
+.nav-mega__pill--family{border-color:#60a5fa;color:#60a5fa}
+.nav-mega__pill--environment{border-color:#10b981;color:#10b981}
+.nav-mega__pill--spirituality{border-color:#8b5cf6;color:#8b5cf6}
+.nav-mega__tools{margin-left:auto;display:flex;gap:8px;align-items:center;flex-wrap:wrap}
+.nav-mega__search input,.nav-mega__select{border:1px solid var(--nav-mega-line);border-radius:10px;padding:8px 10px;font:inherit;background:#fff;color:var(--nav-mega-ink);min-height:36px}
+.nav-mega__search input{width:220px}
+.nav-mega__modebtn{border:1px solid var(--nav-mega-line);background:#fff;border-radius:10px;padding:8px 12px;cursor:pointer;font-weight:600;color:var(--nav-mega-ink);transition:border-color .2s ease,color .2s ease,background .2s ease}
+.nav-mega__scroll{overflow:auto;max-height:360px;border-radius:14px;border:1px solid var(--nav-mega-line);background:#fff}
+.nav-mega__table{width:100%;border-collapse:collapse;min-width:520px}
+.nav-mega__table th,.nav-mega__table td{padding:10px 14px;border-bottom:1px solid var(--nav-mega-line);text-align:left;font-size:.88rem;color:var(--nav-mega-ink);vertical-align:top}
+.nav-mega__table th{background:var(--nav-mega-soft);font-weight:700;font-size:.72rem;letter-spacing:.06em;text-transform:uppercase;color:#334155}
+.nav-mega__table tr:hover td{background:#fdfdff}
+.nav-mega__table tr:last-child td{border-bottom:none}
+.nav-mega__product-link{display:inline-flex;align-items:center;gap:6px;font-weight:600;color:var(--nav-mega-ink);text-decoration:none}
+.nav-mega__product-link:hover,.nav-mega__product-link:focus-visible{color:#1d4ed8;text-decoration:none;outline:none}
+.nav-mega__product-sub{margin-top:4px;font-size:.78rem;color:var(--nav-mega-muted)}
+.nav-mega__tbadge{display:inline-flex;align-items:center;gap:4px;border:1px solid var(--nav-mega-line);border-radius:999px;padding:2px 8px;font-size:.68rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;color:var(--nav-mega-muted);background:#fff}
+.nav-mega__price{font-weight:700}
+.nav-mega__empty-row td{color:var(--nav-mega-muted);font-style:italic}
+.nav-mega__pager{display:flex;align-items:center;gap:10px;justify-content:flex-end;margin-top:6px;flex-wrap:wrap}
+.nav-mega__pager-info{margin-right:auto;color:var(--nav-mega-muted);font-size:.78rem;display:flex;gap:8px;align-items:center}
+.nav-mega__pager-info a{color:#1d4ed8;font-weight:600;text-decoration:none}
+.nav-mega__pager-info a:hover,.nav-mega__pager-info a:focus-visible{text-decoration:underline;outline:none}
+.nav-mega__pager button{border:1px solid var(--nav-mega-line);background:#fff;border-radius:10px;padding:6px 12px;cursor:pointer;font:inherit;font-weight:600;color:var(--nav-mega-ink);transition:border-color .2s ease,color .2s ease,background .2s ease}
+.nav-mega__pager button:hover:not(:disabled){border-color:#94a3b8;color:#0f172a}
+.nav-mega__pager button:disabled{opacity:.4;cursor:not-allowed}
+.nav-mega__panel button:focus-visible,.nav-mega__panel input:focus-visible,.nav-mega__panel select:focus-visible{outline:2px solid #4338ca;outline-offset:2px}
+.nav-mega__panel.is-tinted .nav-mega__cats{background:color-mix(in srgb,var(--nav-mega-acc) 6%,var(--nav-mega-soft))}
+.nav-mega__panel.is-tinted .nav-mega__catbtn[aria-current="true"]{border-color:var(--nav-mega-acc);box-shadow:0 0 0 3px color-mix(in srgb,var(--nav-mega-acc) 16%,transparent)}
+.nav-mega__panel.is-tinted .nav-mega__pill{border-color:var(--nav-mega-acc);color:var(--nav-mega-acc);background:color-mix(in srgb,var(--nav-mega-acc) 12%,#fff)}
+.nav-mega__panel.is-tinted .nav-mega__modebtn{border-color:var(--nav-mega-acc);color:var(--nav-mega-acc)}
+.nav-mega__panel.is-tinted .nav-mega__scroll{border-color:color-mix(in srgb,var(--nav-mega-acc) 32%,var(--nav-mega-line))}
+.nav-mega__panel.is-tinted .nav-mega__table th{background:color-mix(in srgb,var(--nav-mega-acc) 10%,#fff)}
+.nav-mega__panel.is-tinted .nav-mega__table tr:hover td{background:color-mix(in srgb,var(--nav-mega-acc) 8%,#fff)}
+.nav-mega__panel.is-tinted .nav-mega__table tr:hover td:first-child{box-shadow:inset 3px 0 0 0 var(--nav-mega-acc)}
+.nav-mega__panel.is-tinted .nav-mega__pager button:hover:not(:disabled){border-color:var(--nav-mega-acc);color:var(--nav-mega-acc)}
+.nav-mega__panel.is-tinted .nav-mega__tbadge[data-type="new"]{background:color-mix(in srgb,var(--nav-mega-acc) 18%,#fff);border-color:var(--nav-mega-acc);color:#0f172a}
+.nav-mega__panel.is-tinted .nav-mega__tbadge[data-type="popular"]{background:#fff7ed;border-color:#fdba74;color:#9a3412}
+.nav-mega__panel.is-tinted .nav-mega__tbadge[data-type="bestseller"]{background:#ecfeff;border-color:#67e8f9;color:#155e75}
 .nav-mega__placeholder{margin:0;color:#475569}
-.nav-mega__footer{display:flex;justify-content:center;padding-top:12px;border-top:1px solid rgba(148,163,184,.2)}
-.nav-mega__footer a{font-weight:600;color:#1d4ed8}
 .nav-item--bundles{position:relative}
 .nav-link--bundles::after{content:"▾";font-size:.68em;margin-left:6px;transition:transform .2s ease}
 .nav-item--bundles.is-open>.nav-link--bundles::after,.nav-item--bundles:hover>.nav-link--bundles::after{transform:rotate(180deg)}
@@ -132,8 +185,9 @@ body[class*="theme-midnight"]{
   .nav-link:focus-visible{background:rgba(255,255,255,.95);box-shadow:0 12px 26px rgba(15,23,42,.2);border-color:rgba(148,163,184,.35);}
 }
 
-@media(max-width:1040px){
-  .nav-mega__grid{grid-template-columns:repeat(auto-fit,minmax(220px,1fr))}
+@media(max-width:960px){
+  .nav-mega__pane{grid-template-columns:1fr}
+  .nav-mega__cats{border-right:0;border-bottom:1px solid var(--nav-mega-line)}
 }
 
 .hero.minimal{padding:70px 24px;text-align:center;max-width:920px;margin:0 auto}


### PR DESCRIPTION
## Summary
- restyle the "Discover Life Harmony" navigation mega menu to use the new two-column layout with category list, search, sorting, pagination, and color-tint toggle
- seed navigation data with curated products per life area and expose accent color metadata for the new presentation
- keep bundle flyout behaviour intact while integrating the new browse experience

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d2ce4b7d0c832d81a04dbdc04030d5