### PR TITLE
Add rotating hero headline on home page

### DIFF
--- a/app.js
+++ b/app.js
@@ -250,6 +250,59 @@ App.LIFE_AREAS = {
   }
 };
 
+/*****************************************************
+ * Hero headline rotation (index)
+ *****************************************************/
+App.HERO_ROTATIONS = [
+  { text: "Create Harmony in Your Life", color: "#6366F1" },
+  { text: "From Chaos to Clarity", color: "#14B8A6" },
+  { text: "Bring Balance to Your Day", color: "#F97316" }
+];
+
+App.initHeroRotation = function() {
+  const target = App.qs("[data-hero-rotate]");
+  if (!target || target.dataset.heroRotationInit === "true") return;
+
+  target.dataset.heroRotationInit = "true";
+
+  const phrases = Array.isArray(App.HERO_ROTATIONS)
+    ? App.HERO_ROTATIONS.filter(item => item && item.text)
+    : [];
+  if (!phrases.length) return;
+
+  const applyPhrase = phrase => {
+    target.textContent = phrase.text;
+    if (phrase.color) {
+      target.style.setProperty("--hero-rotate-color", phrase.color);
+    } else {
+      target.style.removeProperty("--hero-rotate-color");
+    }
+  };
+
+  applyPhrase(phrases[0]);
+
+  const prefersReducedMotion =
+    typeof window !== "undefined" &&
+    typeof window.matchMedia === "function" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches;
+  if (prefersReducedMotion || phrases.length === 1) return;
+
+  let index = 0;
+  const fadeDuration = 260;
+  const intervalDuration = 5200;
+
+  window.setInterval(() => {
+    target.classList.add("is-changing");
+    window.setTimeout(() => {
+      index = (index + 1) % phrases.length;
+      applyPhrase(phrases[index]);
+      window.requestAnimationFrame(() => {
+        target.classList.remove("is-changing");
+      });
+    }, fadeDuration);
+  }, intervalDuration);
+};
+
 App.NAV_PRODUCT_META = {
   pomodoro: {
     type: "Focus System",
@@ -712,6 +765,9 @@ App.init = function() {
 
   // Build enhanced browse menu
   App.initNavDropdown();
+
+  // Hero headline rotation (home page)
+  App.initHeroRotation();
 
   // Auto-detect page
   if (App.qs("body.page-products")) App.initProducts();

--- a/index.html
+++ b/index.html
@@ -69,7 +69,10 @@
 
 <main>
   <section class="hero minimal">
-    <h1>Create harmony with smart spreadsheet tools</h1>
+    <h1 class="hero-heading">
+      <span class="hero-heading__dynamic" data-hero-rotate>Create Harmony in Your Life</span>
+      <span class="hero-heading__tagline" aria-label="- Powered by Next-Gen Google Sheets">Powered by Next-Gen Google Sheets</span>
+    </h1>
     <p>Elegant, app-like interfaces on top of spreadsheet “databases.”<br>
        <strong>One-time purchase. No subscriptions. You own the tool.</strong></p>
     <div class="hero-cta">

--- a/style.css
+++ b/style.css
@@ -190,6 +190,13 @@ body[class*="theme-midnight"]{
 
 .hero.minimal{padding:70px 24px;text-align:center;max-width:920px;margin:0 auto}
 .hero h1{margin:0 0 10px;font-size:42px;line-height:1.1}
+.hero-heading{display:flex;flex-wrap:wrap;justify-content:center;align-items:flex-end;gap:clamp(.45rem,2vw,.75rem);text-align:center}
+.hero-heading__dynamic{display:inline-block;font-weight:700;color:var(--hero-rotate-color,#6366f1);transition:color .6s ease,opacity .35s ease,transform .35s ease}
+.hero-heading__dynamic.is-changing{opacity:0;transform:translateY(12px)}
+.hero-heading__tagline{display:inline-flex;align-items:center;gap:.4ch;padding:clamp(.18rem,.7vw,.32rem) clamp(.48rem,1.4vw,.82rem);border-radius:999px;border:1px solid rgba(15,23,42,.14);background:rgba(15,23,42,.06);color:#0f172a;font-weight:700;text-transform:uppercase;letter-spacing:.12em;font-size:clamp(.52rem,.46rem + .8vw,.9rem);box-shadow:0 14px 34px rgba(15,23,42,.08);white-space:nowrap;line-height:1.3}
+.hero-heading__tagline::before{content:"-";font-size:1.05em;line-height:1;opacity:.7;transform:translateY(-.04em)}
+.hero h1 .hero-heading__dynamic,.hero h1 .hero-heading__tagline{line-height:1.1}
+.hero-heading__dynamic::after{content:"";display:block;width:100%;height:2px;margin-top:6px;background:linear-gradient(90deg,currentColor 0%,rgba(99,102,241,0) 100%);opacity:.2}
 .hero p{color:var(--muted)}
 .hero-cta{margin-top:18px;display:flex;gap:10px;justify-content:center}
 .btn{display:inline-block;padding:11px 16px;border:1px solid var(--brand);border-radius:10px;box-shadow:var(--shadow)}


### PR DESCRIPTION
## Summary
- replace the home hero heading with a rotating message that cycles through three phrases and keeps a permanent Google Sheets tagline
- style the dynamic hero headline and tagline pill so the color shifts with each message
- add a hero rotation initializer that updates the headline on an interval and respects `prefers-reduced-motion`

## Testing
- No tests were run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68d3d7fc703c832da27e6898c8e3753d