### PR TITLE
Add header logo and Pomodoro gallery image

### DIFF
--- a/about.html
+++ b/about.html
@@ -9,7 +9,10 @@
 </head>
 <body class="theme-neutral">
 <header class="site-header">
-  <a class="brand" href="/">Harmony Sheets</a>
+  <a class="brand" href="/">
+    <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
+    <span>Harmony Sheets</span>
+  </a>
   <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">
     <span class="sr-only">Toggle navigation</span>
     <span class="nav-toggle__icon" aria-hidden="true"></span>

--- a/affiliate.html
+++ b/affiliate.html
@@ -9,7 +9,10 @@
 </head>
 <body class="theme-neutral page-affiliate">
 <header class="site-header">
-  <a class="brand" href="/">Harmony Sheets</a>
+  <a class="brand" href="/">
+    <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
+    <span>Harmony Sheets</span>
+  </a>
   <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">
     <span class="sr-only">Toggle navigation</span>
     <span class="nav-toggle__icon" aria-hidden="true"></span>

--- a/app.js
+++ b/app.js
@@ -2143,6 +2143,34 @@ App.initProduct = async function() {
     const product = products.find(p => p.id === productId);
     if (!product) return;
 
+    // Gallery images
+    const galleryEl = App.qs("#p-slider");
+    if (galleryEl) {
+      const slides = Array.isArray(product.gallery) ? product.gallery.filter(item => item && item.src) : [];
+      if (!slides.length) {
+        galleryEl.innerHTML = "";
+        galleryEl.style.display = "none";
+      } else {
+        galleryEl.style.removeProperty("display");
+        const fallbackBase = product.name ? `${product.name} preview` : "Product preview";
+        const totalSlides = slides.length;
+        const slidesMarkup = slides
+          .map((item, index) => {
+            const src = App.escapeHtml(item.src);
+            const rawAlt = typeof item.alt === "string" ? item.alt.trim() : "";
+            const altSource = rawAlt || (totalSlides > 1 ? `${fallbackBase} ${index + 1}` : fallbackBase);
+            const alt = App.escapeHtml(altSource);
+            const styleAttr = index === 0 ? ' style="display:block;"' : "";
+            return `<div class="slide"${styleAttr}><img src="${src}" alt="${alt}"></div>`;
+          })
+          .join("\n");
+        const navMarkup = totalSlides > 1
+          ? `\n<button class="prev" aria-label="Previous">‹</button>\n<button class="next" aria-label="Next">›</button>`
+          : "";
+        galleryEl.innerHTML = `${slidesMarkup}${navMarkup}`;
+      }
+    }
+
     // Title + name
     document.title = product.name + " — Harmony Sheets";
     App.qs("#p-name").textContent = product.name;

--- a/bundles.html
+++ b/bundles.html
@@ -9,7 +9,10 @@
 </head>
 <body class="theme-neutral">
 <header class="site-header">
-  <a class="brand" href="/">Harmony Sheets</a>
+  <a class="brand" href="/">
+    <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
+    <span>Harmony Sheets</span>
+  </a>
   <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">
     <span class="sr-only">Toggle navigation</span>
     <span class="nav-toggle__icon" aria-hidden="true"></span>

--- a/faq.html
+++ b/faq.html
@@ -9,7 +9,10 @@
 </head>
 <body class="theme-neutral">
 <header class="site-header">
-  <a class="brand" href="/">Harmony Sheets</a>
+  <a class="brand" href="/">
+    <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
+    <span>Harmony Sheets</span>
+  </a>
   <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">
     <span class="sr-only">Toggle navigation</span>
     <span class="nav-toggle__icon" aria-hidden="true"></span>

--- a/index.html
+++ b/index.html
@@ -10,7 +10,10 @@
 </head>
 <body class="theme-neutral">
 <header class="site-header">
-  <a class="brand" href="/">Harmony Sheets</a>
+  <a class="brand" href="/">
+    <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
+    <span>Harmony Sheets</span>
+  </a>
   <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">
     <span class="sr-only">Toggle navigation</span>
     <span class="nav-toggle__icon" aria-hidden="true"></span>

--- a/policies.html
+++ b/policies.html
@@ -9,7 +9,10 @@
 </head>
 <body class="theme-neutral page-policies">
 <header class="site-header">
-  <a class="brand" href="/">Harmony Sheets</a>
+  <a class="brand" href="/">
+    <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
+    <span>Harmony Sheets</span>
+  </a>
   <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">
     <span class="sr-only">Toggle navigation</span>
     <span class="nav-toggle__icon" aria-hidden="true"></span>

--- a/product.html
+++ b/product.html
@@ -10,7 +10,10 @@
 
 <body class="page-product">
   <header class="site-header">
-    <a class="brand" href="/">Harmony Sheets</a>
+    <a class="brand" href="/">
+      <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
+      <span>Harmony Sheets</span>
+    </a>
     <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">
       <span class="sr-only">Toggle navigation</span>
       <span class="nav-toggle__icon" aria-hidden="true"></span>

--- a/products.html
+++ b/products.html
@@ -9,7 +9,10 @@
 </head>
 <body class="page-products">
   <header class="site-header">
-    <a class="brand" href="/">Harmony Sheets</a>
+    <a class="brand" href="/">
+      <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
+      <span>Harmony Sheets</span>
+    </a>
     <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">
       <span class="sr-only">Toggle navigation</span>
       <span class="nav-toggle__icon" aria-hidden="true"></span>

--- a/products.json
+++ b/products.json
@@ -18,6 +18,9 @@
       "Optional session logging"
     ],
     "description": "<p>This Pomodoro timer helps you <strong>start fast and stay consistent</strong>. Auto-start cycles keep you in flow, optional sound alerts give gentle nudges, and counters track your daily focus without effort.</p>",
+    "gallery": [
+      { "src": "assets/Pomodoro1.webp", "alt": "Screenshot of the Harmony Sheets Pomodoro timer" }
+    ],
     "colorImage": "assets/pomodoro-colors.webp",
     "colorCaption": "Pick a theme that feels calm and keeps you focused.",
     "demoVideo": "assets/pomodoro-demo.mp4",

--- a/style.css
+++ b/style.css
@@ -21,6 +21,7 @@ img{max-width:100%;display:block}
 
 .site-header{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:14px 20px;border-bottom:1px solid var(--border);position:sticky;top:0;background:rgba(255,255,255,.96);backdrop-filter:saturate(150%) blur(14px);z-index:60}
 .brand{display:inline-flex;align-items:center;gap:8px;font-weight:700;font-size:1.12rem;letter-spacing:.02em;color:#0f172a;text-decoration:none;transition:color .2s ease}
+.brand__logo{width:32px;height:32px;object-fit:contain;display:block;flex-shrink:0}
 .brand:hover,.brand:focus-visible{color:#1d4ed8}
 .main-nav{display:flex;align-items:center;gap:10px;padding:6px 8px;border-radius:999px;background:rgba(255,255,255,.78);border:1px solid rgba(148,163,184,.22);box-shadow:0 12px 30px rgba(15,23,42,.08);position:relative}
 .nav-item{position:relative}
@@ -430,8 +431,15 @@ body[class*="theme-midnight"]{
 .hero{display:grid;grid-template-columns:minmax(0,1fr) 480px;gap:28px;align-items:start;padding:24px 0;padding-block:24px}
 @media (max-width:960px){.hero{grid-template-columns:1fr}}
 .hero .media{border-radius:14px;box-shadow:0 10px 30px rgba(0,0,0,.08);overflow:hidden;background:#fff}
-.hero .gallery{position:relative}
+.hero .gallery{position:relative;background:#f8fafc}
+.hero .gallery .slide{display:none}
+.hero .gallery .slide:first-child{display:block}
 .hero .gallery .slide img{display:block;width:100%;height:auto}
+.hero .gallery button{position:absolute;top:50%;transform:translateY(-50%);display:flex;align-items:center;justify-content:center;width:40px;height:40px;border-radius:999px;border:1px solid rgba(15,23,42,.12);background:rgba(255,255,255,.92);color:#0f172a;font-size:1.65rem;cursor:pointer;box-shadow:0 12px 28px rgba(15,23,42,.12);transition:background .2s ease,color .2s ease,box-shadow .2s ease}
+.hero .gallery button:hover,.hero .gallery button:focus-visible{background:#fff;color:#1d4ed8;box-shadow:0 14px 32px rgba(15,23,42,.16)}
+.hero .gallery button:focus-visible{outline:2px solid var(--brand);outline-offset:2px}
+.hero .gallery .prev{left:16px}
+.hero .gallery .next{right:16px}
 .hero .info h1{margin:0 0 .25rem 0;font-size:clamp(1.5rem,2.5vw,2rem)}
 .tagline{margin:.25rem 0 1rem 0;color:#555}
 .price{font-weight:700;margin:.25rem 0 1rem 0}


### PR DESCRIPTION
## Summary
- display the Harmony Sheets logo next to the brand name across site headers
- style the new brand logo and gallery navigation for consistent presentation
- load the new Pomodoro screenshot into the product gallery with gallery rendering support

## Testing
- Not run (static content changes)


------
https://chatgpt.com/codex/tasks/task_e_68d3dcdafe80832d938b99700a5dcef0