### PR TITLE
Simplify Discover menu layout

### DIFF
--- a/app.js
+++ b/app.js
@@ -964,8 +964,7 @@ App.initNavDropdown = function() {
   const navState = {
     cat: areaOrder[0],
     q: "",
-    sort: "name",
-    tinted: true
+    sort: "name"
   };
 
   const formatPriceDisplay = value => {
@@ -1085,7 +1084,6 @@ App.initNavDropdown = function() {
   let infoTextEl = null;
   let searchInput = null;
   let sortSelect = null;
-  let modeBtn = null;
 
   const collectSearchableItems = () => {
     const aggregated = [];
@@ -1159,17 +1157,11 @@ App.initNavDropdown = function() {
     const accent = navAccentMap[navState.cat] || info.color || "#7c5cff";
     panelEl.dataset.area = navState.cat;
     panelEl.style.setProperty("--nav-mega-acc", accent);
-    panelEl.classList.toggle("is-tinted", Boolean(navState.tinted));
 
     const safeCatClass = navState.cat.replace(/[^a-z0-9-]/g, "");
     if (pillEl) {
       pillEl.textContent = info.title || "Life Harmony";
       pillEl.className = `nav-mega__pill nav-mega__pill--${safeCatClass}`;
-    }
-
-    if (modeBtn) {
-      modeBtn.setAttribute("aria-pressed", navState.tinted ? "true" : "false");
-      modeBtn.textContent = `Color mode: ${navState.tinted ? "On" : "Off"}`;
     }
 
     if (searchInput && searchInput.value !== navState.q) {
@@ -1216,7 +1208,7 @@ App.initNavDropdown = function() {
         const message = query
           ? `No matches for “${navState.q}”.`
           : info.empty || "Fresh tools coming soon.";
-        rowsEl.innerHTML = `<tr class="nav-mega__empty-row"><td colspan="5">${App.escapeHtml(message)}</td></tr>`;
+        rowsEl.innerHTML = `<tr class="nav-mega__empty-row"><td colspan="4">${App.escapeHtml(message)}</td></tr>`;
       } else {
         const rows = sorted
           .map(item => {
@@ -1225,17 +1217,10 @@ App.initNavDropdown = function() {
               ? `<span class="nav-mega__tbadge"${badgeType ? ` data-type="${badgeType}"` : ""}>${App.escapeHtml(item.badge)}</span>`
               : "";
             const priceText = item.priceDisplay ? App.escapeHtml(item.priceDisplay) : "—";
-            const detailParts = [];
-            if (query && item.lifeAreaLabel) detailParts.push(item.lifeAreaLabel);
-            if (item.tagline) detailParts.push(item.tagline);
-            const detail = detailParts.length
-              ? `<div class="nav-mega__product-sub">${detailParts.map(part => App.escapeHtml(part)).join(" • ")}</div>`
-              : "";
             const url = App.escapeHtml(item.url || `products.html?area=${encodeURIComponent(navState.cat)}`);
             const name = App.escapeHtml(item.name || "Harmony Sheets tool");
             const type = App.escapeHtml(item.type || "Template");
-            const format = App.escapeHtml(item.format || "Sheets");
-            return `<tr><td><a class="nav-mega__product-link" href="${url}">${name}</a>${detail}</td><td>${type}</td><td>${format}</td><td>${badgeMarkup}</td><td class="nav-mega__price">${priceText}</td></tr>`;
+            return `<tr><td><a class="nav-mega__product-link" href="${url}">${name}</a></td><td>${type}</td><td>${badgeMarkup}</td><td class="nav-mega__price">${priceText}</td></tr>`;
           })
           .join("");
         rowsEl.innerHTML = rows;
@@ -1279,7 +1264,7 @@ App.initNavDropdown = function() {
       .join("");
 
     content.innerHTML = `
-      <div class="nav-mega__panel is-tinted" data-nav-panel data-area="${App.escapeHtml(navState.cat)}">
+      <div class="nav-mega__panel" data-nav-panel data-area="${App.escapeHtml(navState.cat)}">
         <div class="nav-mega__pane">
           <aside class="nav-mega__cats">
             <div class="nav-mega__cats-head">Explore</div>
@@ -1300,22 +1285,20 @@ App.initNavDropdown = function() {
                   <option value="price"${navState.sort === "price" ? " selected" : ""}>Sort: Price</option>
                   <option value="badge"${navState.sort === "badge" ? " selected" : ""}>Sort: Badge</option>
                 </select>
-                <button class="nav-mega__modebtn" type="button" data-nav-mode aria-pressed="${navState.tinted ? "true" : "false"}">Color mode: ${navState.tinted ? "On" : "Off"}</button>
               </div>
             </div>
             <div class="nav-mega__scroll">
               <table class="nav-mega__table" aria-describedby="${pillId}">
                 <thead>
                   <tr>
-                    <th scope="col" style="width:40%">Product</th>
-                    <th scope="col" style="width:18%">Type</th>
-                    <th scope="col" style="width:18%">Format</th>
-                    <th scope="col" style="width:10%">Badge</th>
-                    <th scope="col" style="width:14%">Price</th>
+                    <th scope="col" style="width:54%">Product</th>
+                    <th scope="col" style="width:20%">Type</th>
+                    <th scope="col" style="width:14%">Badge</th>
+                    <th scope="col" style="width:12%">Price</th>
                   </tr>
                 </thead>
                 <tbody data-nav-rows>
-                  <tr class="nav-mega__empty-row"><td colspan="5">Loading Life Harmony tools…</td></tr>
+                  <tr class="nav-mega__empty-row"><td colspan="4">Loading Life Harmony tools…</td></tr>
                 </tbody>
               </table>
             </div>
@@ -1334,7 +1317,6 @@ App.initNavDropdown = function() {
     infoTextEl = content.querySelector("[data-nav-info]");
     searchInput = content.querySelector("[data-nav-search]");
     sortSelect = content.querySelector("[data-nav-sort]");
-    modeBtn = content.querySelector("[data-nav-mode]");
 
     catButtonMap.clear();
     content.querySelectorAll("[data-nav-cat]").forEach(btn => {
@@ -1358,13 +1340,6 @@ App.initNavDropdown = function() {
     if (sortSelect) {
       sortSelect.addEventListener("change", event => {
         navState.sort = event.target.value || "name";
-        updateActive();
-      });
-    }
-
-    if (modeBtn) {
-      modeBtn.addEventListener("click", () => {
-        navState.tinted = !navState.tinted;
         updateActive();
       });
     }

--- a/style.css
+++ b/style.css
@@ -61,7 +61,7 @@ button.nav-link{border:0;background:transparent;cursor:pointer;font:inherit}
 .nav-mega__count{margin-left:auto;color:var(--nav-mega-muted);font-size:.78rem}
 .nav-mega__prod{padding:16px 18px;display:flex;flex-direction:column;gap:12px}
 .nav-mega__prod-head{display:flex;align-items:center;gap:12px;flex-wrap:wrap}
-.nav-mega__pill{border:1px solid var(--nav-mega-line);padding:4px 12px;border-radius:999px;font-weight:700;font-size:.72rem;letter-spacing:.06em;text-transform:uppercase;color:var(--nav-mega-muted)}
+.nav-mega__pill{border:1px solid var(--nav-mega-acc);padding:4px 12px;border-radius:999px;font-weight:700;font-size:.72rem;letter-spacing:.06em;text-transform:uppercase;color:var(--nav-mega-acc);background:#fff;background:color-mix(in srgb,var(--nav-mega-acc) 12%,#fff)}
 .nav-mega__pill--love{border-color:#ef5da8;color:#ef5da8}
 .nav-mega__pill--career{border-color:#7c5cff;color:#7c5cff}
 .nav-mega__pill--health{border-color:#22c55e;color:#22c55e}
@@ -73,37 +73,26 @@ button.nav-link{border:0;background:transparent;cursor:pointer;font:inherit}
 .nav-mega__tools{margin-left:auto;display:flex;gap:8px;align-items:center;flex-wrap:wrap}
 .nav-mega__search input,.nav-mega__select{border:1px solid var(--nav-mega-line);border-radius:10px;padding:8px 10px;font:inherit;background:#fff;color:var(--nav-mega-ink);min-height:36px}
 .nav-mega__search input{width:220px}
-.nav-mega__modebtn{border:1px solid var(--nav-mega-line);background:#fff;border-radius:10px;padding:8px 12px;cursor:pointer;font-weight:600;color:var(--nav-mega-ink);transition:border-color .2s ease,color .2s ease,background .2s ease}
 .nav-mega__scroll{overflow:auto;max-height:360px;border-radius:14px;border:1px solid var(--nav-mega-line);background:#fff}
 .nav-mega__table{width:100%;border-collapse:collapse;min-width:520px}
 .nav-mega__table th,.nav-mega__table td{padding:10px 14px;border-bottom:1px solid var(--nav-mega-line);text-align:left;font-size:.96rem;color:var(--nav-mega-ink);vertical-align:top}
 .nav-mega__table th{background:var(--nav-mega-soft);font-weight:700;font-size:.78rem;letter-spacing:.06em;text-transform:uppercase;color:#334155}
 .nav-mega__table tr:hover td{background:#fdfdff}
 .nav-mega__table tr:last-child td{border-bottom:none}
-.nav-mega__product-link{display:inline-flex;align-items:center;gap:6px;font-weight:600;color:var(--nav-mega-ink);text-decoration:none}
+.nav-mega__product-link{display:inline-flex;align-items:center;gap:6px;font-weight:600;color:var(--nav-mega-ink);text-decoration:none;flex-wrap:wrap}
 .nav-mega__product-link:hover,.nav-mega__product-link:focus-visible{color:#1d4ed8;text-decoration:none;outline:none}
 .nav-mega__product-sub{margin-top:4px;font-size:.84rem;color:var(--nav-mega-muted)}
 .nav-mega__tbadge{display:inline-flex;align-items:center;gap:4px;border:1px solid var(--nav-mega-line);border-radius:999px;padding:2px 8px;font-size:.68rem;font-weight:700;letter-spacing:.04em;text-transform:uppercase;color:var(--nav-mega-muted);background:#fff}
+.nav-mega__tbadge[data-type="new"]{background:color-mix(in srgb,var(--nav-mega-acc) 18%,#fff);border-color:var(--nav-mega-acc);color:#0f172a}
+.nav-mega__tbadge[data-type="popular"]{background:#fff7ed;border-color:#fdba74;color:#9a3412}
+.nav-mega__tbadge[data-type="bestseller"]{background:#ecfeff;border-color:#67e8f9;color:#155e75}
 .nav-mega__price{font-weight:700}
 .nav-mega__empty-row td{color:var(--nav-mega-muted);font-style:italic}
 .nav-mega__pager{display:flex;align-items:center;gap:12px;justify-content:space-between;margin-top:10px;flex-wrap:wrap}
 .nav-mega__pager-info{color:var(--nav-mega-muted);font-size:.82rem;display:inline-flex;align-items:center;gap:8px}
-.nav-mega__pager-link{color:#1d4ed8;font-weight:600;text-decoration:none}
-.nav-mega__pager-link:hover,.nav-mega__pager-link:focus-visible{text-decoration:underline;outline:none}
+.nav-mega__pager-link{color:var(--nav-mega-acc);font-weight:600;text-decoration:none}
+.nav-mega__pager-link:hover,.nav-mega__pager-link:focus-visible{color:var(--nav-mega-acc);text-decoration:underline;outline:none}
 .nav-mega__panel button:focus-visible,.nav-mega__panel input:focus-visible,.nav-mega__panel select:focus-visible{outline:2px solid #4338ca;outline-offset:2px}
-.nav-mega__panel.is-tinted .nav-mega__cats{background:color-mix(in srgb,var(--nav-mega-acc) 6%,var(--nav-mega-soft))}
-.nav-mega__panel.is-tinted .nav-mega__catbtn[aria-current="true"]{border-color:var(--nav-mega-acc);box-shadow:0 0 0 3px color-mix(in srgb,var(--nav-mega-acc) 16%,transparent)}
-.nav-mega__panel.is-tinted .nav-mega__pill{border-color:var(--nav-mega-acc);color:var(--nav-mega-acc);background:color-mix(in srgb,var(--nav-mega-acc) 12%,#fff)}
-.nav-mega__panel.is-tinted .nav-mega__modebtn{border-color:var(--nav-mega-acc);color:var(--nav-mega-acc)}
-.nav-mega__panel.is-tinted .nav-mega__scroll{border-color:color-mix(in srgb,var(--nav-mega-acc) 32%,var(--nav-mega-line))}
-.nav-mega__panel.is-tinted .nav-mega__table th{background:color-mix(in srgb,var(--nav-mega-acc) 10%,#fff)}
-.nav-mega__panel.is-tinted .nav-mega__table tr:hover td{background:color-mix(in srgb,var(--nav-mega-acc) 8%,#fff)}
-.nav-mega__panel.is-tinted .nav-mega__table tr:hover td:first-child{box-shadow:inset 3px 0 0 0 var(--nav-mega-acc)}
-.nav-mega__panel.is-tinted .nav-mega__pager-link{color:var(--nav-mega-acc)}
-.nav-mega__panel.is-tinted .nav-mega__pager-link:hover,.nav-mega__panel.is-tinted .nav-mega__pager-link:focus-visible{color:var(--nav-mega-acc)}
-.nav-mega__panel.is-tinted .nav-mega__tbadge[data-type="new"]{background:color-mix(in srgb,var(--nav-mega-acc) 18%,#fff);border-color:var(--nav-mega-acc);color:#0f172a}
-.nav-mega__panel.is-tinted .nav-mega__tbadge[data-type="popular"]{background:#fff7ed;border-color:#fdba74;color:#9a3412}
-.nav-mega__panel.is-tinted .nav-mega__tbadge[data-type="bestseller"]{background:#ecfeff;border-color:#67e8f9;color:#155e75}
 .nav-mega__placeholder{margin:0;color:#475569}
 .nav-item--bundles{position:relative}
 .nav-link--bundles::after{content:"▾";font-size:.68em;margin-left:6px;transition:transform .2s ease}


### PR DESCRIPTION
## Summary
- remove the color mode toggle and default the Discover mega menu to the neutral theme while keeping the pill, badges, and browse link tinted
- drop the redundant Format column and extra tagline text so product rows have more room for longer titles and badges
- refresh styles so accent colors stay on the key elements even in neutral mode

## Testing
- No automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d3e868bb1c832d8c460b4218d6a317