### PR TITLE
Revamp bundles navigation and add detail pages

### DIFF
--- a/app.js
+++ b/app.js
@@ -1451,24 +1451,43 @@ App.initNavDropdown = function() {
     const markup = featured
       .map(item => {
         const slug = App.slugify(item.slug || item.id || item.name || "");
+        const detailPage = item.page || item.detailPage || item.detail || item.detail_page;
         const hrefId = slug ? `#bundle-${slug}` : "";
-        const href = App.escapeHtml(`bundles.html${hrefId}`);
+        const rawHref = detailPage ? detailPage : `bundles.html${hrefId}`;
+        const href = App.escapeHtml(rawHref);
         const name = App.escapeHtml(item.name || item.title || "Bundle");
         const desc = App.escapeHtml(item.navTagline || item.tagline || "");
+        const badge = App.escapeHtml(item.badge || "Bundle");
+        const price = App.escapeHtml(item.price || "");
+        const savings = App.escapeHtml(item.savings || "");
+        const includes = Array.isArray(item.includes) ? item.includes.filter(Boolean).slice(0, 3) : [];
+        const includeMarkup = includes.length
+          ? `<ul class="nav-bundle-card__includes">${includes
+              .map(include => `<li>${App.escapeHtml(include)}</li>`)
+              .join("")}</ul>`
+          : "";
+        const cta = App.escapeHtml(item.navCta || item.cta || "View bundle");
         const baseColor = item.color || item.navColor || "#6366f1";
         const accent = App.escapeHtml(baseColor);
         const soft = App.escapeHtml(App.hexToRgba(baseColor, 0.18));
         return `
-          <a class="nav-bundles__link" role="menuitem" href="${href}" style="--bundle-accent:${accent};--bundle-accent-soft:${soft};">
-            <span class="nav-bundles__title">${name}</span>
-            ${desc ? `<span class="nav-bundles__desc">${desc}</span>` : ""}
+          <a class="nav-bundle-card" role="menuitem" href="${href}" style="--bundle-accent:${accent};--bundle-accent-soft:${soft};">
+            <span class="nav-bundle-card__badge">${badge}</span>
+            <span class="nav-bundle-card__title">${name}</span>
+            ${desc ? `<span class="nav-bundle-card__tagline">${desc}</span>` : ""}
+            <span class="nav-bundle-card__pricing">
+              ${price ? `<strong>${price}</strong>` : ""}
+              ${savings ? `<em>Save ${savings}</em>` : ""}
+            </span>
+            ${includeMarkup}
+            <span class="nav-bundle-card__cta">${cta}</span>
           </a>
         `;
       })
       .join("");
 
     bundleContent.innerHTML = `
-      <div class="nav-bundles">
+      <div class="nav-bundles-grid">
         ${markup}
       </div>
       <div class="nav-flyout__footer"><a href="bundles.html">View all bundles</a></div>
@@ -1553,7 +1572,15 @@ App.initBundles = async function() {
         const includeMarkup = includes.length
           ? `<ul class="bundle-card__includes">${includes.map(item => `<li>${App.escapeHtml(item)}</li>`).join("")}</ul>`
           : "";
-        const link = bundle.href || bundle.link || bundle.stripe || bundle.stripe_link || "bundles.html";
+        const link =
+          bundle.page ||
+          bundle.detailPage ||
+          bundle.detail_page ||
+          bundle.href ||
+          bundle.link ||
+          bundle.stripe ||
+          bundle.stripe_link ||
+          "bundles.html";
         const safeLink = App.escapeHtml(link);
         const openNew = /^https?:/i.test(link);
         const targetAttrs = openNew ? ' target="_blank" rel="noopener"' : "";

--- a/bundle-back-to-school.html
+++ b/bundle-back-to-school.html
@@ -1,0 +1,249 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Back to School Bundle — Harmony Sheets</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="theme-neutral page-bundle">
+<header class="site-header">
+  <a class="brand" href="/">
+    <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
+    <span>Harmony Sheets</span>
+  </a>
+  <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">
+    <span class="sr-only">Toggle navigation</span>
+    <span class="nav-toggle__icon" aria-hidden="true"></span>
+  </button>
+  <nav class="main-nav" id="site-menu">
+    <div class="nav-item nav-item--browse">
+      <a class="nav-link nav-link--browse" href="products.html" aria-haspopup="true" aria-expanded="false">Discover Life Harmony Apps/Templates</a>
+      <div class="nav-mega" role="menu" aria-label="Life Harmony categories">
+        <div class="nav-mega__content" data-nav-mega-content>
+          <p class="nav-mega__placeholder">Loading Life Harmony areas…</p>
+        </div>
+      </div>
+    </div>
+    <div class="nav-item nav-item--bundles">
+      <a class="nav-link nav-link--bundles" href="bundles.html" aria-haspopup="true" aria-expanded="false">Bundles</a>
+      <div class="nav-flyout" role="menu" aria-label="Featured bundles">
+        <div class="nav-flyout__content" data-nav-bundles>
+          <p class="nav-flyout__placeholder">Loading bundles…</p>
+        </div>
+      </div>
+    </div>
+    <a class="nav-link" href="faq.html">FAQ / Support</a>
+    <a class="nav-link" href="about.html">About</a>
+    <button class="nav-link nav-link--icon" type="button" data-cart-toggle aria-expanded="false" aria-controls="cart-panel">
+      <span class="sr-only" data-cart-label>View cart</span>
+      <svg class="nav-link__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <g fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M3.5 4h2.6l1.6 9.2a1 1 0 0 0 1 .8h8.9a1 1 0 0 0 .97-.76L20 7.5H7.1"/>
+          <circle cx="10" cy="18.5" r="1.25"/>
+          <circle cx="17" cy="18.5" r="1.25"/>
+        </g>
+      </svg>
+      <span class="cart-count" data-cart-count>0</span>
+    </button>
+  </nav>
+</header>
+
+<div class="cart-overlay" data-cart-overlay></div>
+<aside class="cart-panel" id="cart-panel" aria-hidden="true" aria-labelledby="cart-panel-title" role="dialog" aria-modal="true">
+  <div class="cart-panel__header">
+    <h2 id="cart-panel-title">Your cart</h2>
+    <button class="cart-panel__close" type="button" data-cart-close aria-label="Close cart">
+      <span aria-hidden="true">×</span>
+    </button>
+  </div>
+  <div class="cart-panel__body" data-cart-items></div>
+  <div class="cart-panel__footer">
+    <div class="cart-panel__total">
+      <span>Total</span>
+      <strong data-cart-total>$0.00</strong>
+    </div>
+    <button class="btn primary cart-panel__checkout" type="button" data-cart-checkout>Checkout</button>
+    <p class="cart-panel__hint muted">Checkout grants instant access to your Harmony Sheets downloads.</p>
+  </div>
+</aside>
+
+<main>
+  <section class="bundle-hero" style="--bundle-accent:#2563eb;--bundle-accent-soft:rgba(37,99,235,0.18)">
+    <span class="bundle-hero__badge">Student Focus</span>
+    <h1>Back to School Bundle</h1>
+    <p class="bundle-hero__tagline">Reset your semester routines with synchronized study, class, and budget trackers.</p>
+    <div class="bundle-hero__meta">
+      <span class="bundle-hero__price">$49</span>
+      <span class="bundle-hero__savings">Save $18</span>
+    </div>
+    <p class="bundle-hero__description">Give every class, assignment, and commitment a calm command center. This bundle keeps schedules, tasks, and finances aligned so you can spend more energy on learning and less on logistics.</p>
+    <div class="bundle-hero__cta">
+      <a class="btn primary" href="https://buy.stripe.com/test_backtoschool" target="_blank" rel="noopener">Unlock the bundle</a>
+      <a class="btn ghost" href="bundles.html">Back to all bundles</a>
+    </div>
+  </section>
+
+  <section class="bundle-section">
+    <div class="bundle-section__inner">
+      <div class="bundle-section__main">
+        <h2>What&#8217;s inside</h2>
+        <ul class="bundle-modules">
+          <li>
+            <h3>Semester Course Planner</h3>
+            <p>Plot every class, credit, and exam milestone in a single semester overview so your priorities stay visible week after week.</p>
+          </li>
+          <li>
+            <h3>Assignment Tracker Dashboard</h3>
+            <p>Capture readings, essays, labs, and group work with due dates, statuses, and effort estimates to prevent last-minute scrambles.</p>
+          </li>
+          <li>
+            <h3>Weekly Study Schedule</h3>
+            <p>Design repeatable focus blocks for lecture reviews, lab prep, and personal commitments to build steady study rhythms.</p>
+          </li>
+          <li>
+            <h3>Student Budget Snapshot</h3>
+            <p>Watch tuition, rent, books, and spending categories in one calm dashboard so you always know where your money is going.</p>
+          </li>
+        </ul>
+      </div>
+      <aside class="bundle-section__aside">
+        <div class="bundle-highlight">
+          <h3>Perfect for</h3>
+          <ul class="bundle-highlight__list">
+            <li>College and university students managing packed semesters</li>
+            <li>Parents supporting teens with a shared planning hub</li>
+            <li>Adult learners balancing coursework with full-time work</li>
+          </ul>
+        </div>
+        <div class="bundle-highlight">
+          <h3>Bundle savings</h3>
+          <p>Individually these templates total $67. The Back to School Bundle delivers them for $49 so you keep $18 for books, coffee, or lab supplies.</p>
+        </div>
+      </aside>
+    </div>
+  </section>
+
+  <section class="bundle-section">
+    <div class="bundle-section__inner">
+      <div class="bundle-section__main">
+        <h2>Stay ahead every week</h2>
+        <p>Built for students who crave clarity, each sheet works together so nothing slips. The bundle gives you an instant overview of what needs attention today and what&#8217;s coming next.</p>
+        <ul class="bundle-points">
+          <li>
+            <strong>Plan once, reference often.</strong>
+            Outline the semester at the start and rely on filtered dashboards to surface the right tasks at the right moment.
+          </li>
+          <li>
+            <strong>Balance study and life.</strong>
+            Layer personal routines, work shifts, and wellness practices alongside classes so your calendar reflects real life.
+          </li>
+          <li>
+            <strong>Control your spending.</strong>
+            Keep track of stipends, side income, and recurring bills to avoid mid-term money surprises.
+          </li>
+        </ul>
+      </div>
+      <aside class="bundle-section__aside">
+        <div class="bundle-highlight">
+          <h3>Need a quick win?</h3>
+          <p>Duplicate the weekly study schedule for each course and link it to your assignment tracker. You&#8217;ll have a personalized system ready in under 15 minutes.</p>
+        </div>
+        <div class="bundle-highlight">
+          <h3>Formats</h3>
+          <p>All templates are optimized for Google Sheets with app-like toggles, drop-downs, and automation-friendly formulas.</p>
+        </div>
+      </aside>
+    </div>
+  </section>
+
+  <section class="bundle-section bundle-section--cta">
+    <div class="bundle-section__inner">
+      <div class="bundle-cta-panel" style="--bundle-accent:#2563eb;--bundle-accent-soft:rgba(37,99,235,0.18)">
+        <div>
+          <h2>Step into the semester prepared</h2>
+          <p>Build steady routines, eliminate deadline anxiety, and keep your budget on track with one coordinated workspace.</p>
+        </div>
+        <a class="btn primary" href="https://buy.stripe.com/test_backtoschool" target="_blank" rel="noopener">Unlock Back to School Bundle</a>
+      </div>
+    </div>
+  </section>
+</main>
+
+<footer class="site-footer">
+  <div class="site-footer__inner">
+    <div class="site-footer__grid">
+      <div class="site-footer__column">
+        <h3 class="site-footer__heading">Customer Support</h3>
+        <ul class="site-footer__links">
+          <li><a href="faq.html#guides">Information Guides</a></li>
+          <li><a href="faq.html">FAQ / Support</a></li>
+          <li><a href="faq.html#contact">Contact Us</a></li>
+        </ul>
+      </div>
+      <div class="site-footer__column">
+        <h3 class="site-footer__heading">Policies</h3>
+        <ul class="site-footer__links">
+          <li><a href="policies.html#privacy">Privacy Policy</a></li>
+          <li><a href="policies.html#delivery">Delivery Policy</a></li>
+          <li><a href="policies.html#refund">Refund Policy</a></li>
+          <li><a href="policies.html#terms">Terms of Service</a></li>
+        </ul>
+      </div>
+      <div class="site-footer__column">
+        <h3 class="site-footer__heading">Affiliate</h3>
+        <ul class="site-footer__links">
+          <li><a href="affiliate.html#apply">Become an Affiliate</a></li>
+          <li><a href="affiliate.html#login">Affiliate Login</a></li>
+        </ul>
+      </div>
+      <div class="site-footer__column site-footer__column--newsletter">
+        <h3 class="site-footer__heading">Social &amp; Newsletter</h3>
+        <form id="footer-newsletter" class="footer-form">
+          <label class="sr-only" for="footer-email">Email address</label>
+          <div class="footer-form__controls">
+            <input id="footer-email" type="email" name="email" placeholder="Enter email" required>
+            <button type="submit" class="footer-form__submit">Join</button>
+          </div>
+        </form>
+        <p class="site-footer__note">Subscribe to receive exclusive releases, deals, and event updates.</p>
+        <div class="site-footer__social">
+          <a class="site-footer__social-link" href="https://www.instagram.com/harmonysheets" target="_blank" rel="noopener" aria-label="Instagram">
+            <span aria-hidden="true">IG</span>
+          </a>
+          <a class="site-footer__social-link" href="https://www.youtube.com/@HarmonySheets" target="_blank" rel="noopener" aria-label="YouTube">
+            <span aria-hidden="true">YT</span>
+          </a>
+          <a class="site-footer__social-link" href="https://www.pinterest.com/harmonysheets" target="_blank" rel="noopener" aria-label="Pinterest">
+            <span aria-hidden="true">PI</span>
+          </a>
+          <a class="site-footer__social-link" href="mailto:support@harmony-sheets.com" aria-label="Email Harmony Sheets">
+            <span aria-hidden="true">@</span>
+          </a>
+        </div>
+        <p id="footer-newsletter-status" class="site-footer__status" role="status" aria-live="polite"></p>
+      </div>
+    </div>
+    <div class="site-footer__bottom">
+      <div class="site-footer__brand">
+        <a class="brand brand--footer" href="/">Harmony Sheets</a>
+        <p class="site-footer__copy">© <span id="year"></span> Harmony Sheets. All rights reserved.</p>
+        <p class="site-footer__tagline">One-time purchase. No subscriptions.</p>
+      </div>
+      <div class="site-footer__extras">
+        <p class="site-footer__locale">Serving customers worldwide • USD</p>
+        <div class="site-footer__payments">
+          <span class="site-footer__payment">Visa</span>
+          <span class="site-footer__payment">Mastercard</span>
+          <span class="site-footer__payment">Amex</span>
+          <span class="site-footer__payment">PayPal</span>
+          <span class="site-footer__payment">Shop Pay</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</footer>
+<script src="app.js"></script>
+</body>
+</html>

--- a/bundle-full-life-hack.html
+++ b/bundle-full-life-hack.html
@@ -1,0 +1,253 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Full Life Hack Bundle — Harmony Sheets</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="theme-neutral page-bundle">
+<header class="site-header">
+  <a class="brand" href="/">
+    <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
+    <span>Harmony Sheets</span>
+  </a>
+  <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">
+    <span class="sr-only">Toggle navigation</span>
+    <span class="nav-toggle__icon" aria-hidden="true"></span>
+  </button>
+  <nav class="main-nav" id="site-menu">
+    <div class="nav-item nav-item--browse">
+      <a class="nav-link nav-link--browse" href="products.html" aria-haspopup="true" aria-expanded="false">Discover Life Harmony Apps/Templates</a>
+      <div class="nav-mega" role="menu" aria-label="Life Harmony categories">
+        <div class="nav-mega__content" data-nav-mega-content>
+          <p class="nav-mega__placeholder">Loading Life Harmony areas…</p>
+        </div>
+      </div>
+    </div>
+    <div class="nav-item nav-item--bundles">
+      <a class="nav-link nav-link--bundles" href="bundles.html" aria-haspopup="true" aria-expanded="false">Bundles</a>
+      <div class="nav-flyout" role="menu" aria-label="Featured bundles">
+        <div class="nav-flyout__content" data-nav-bundles>
+          <p class="nav-flyout__placeholder">Loading bundles…</p>
+        </div>
+      </div>
+    </div>
+    <a class="nav-link" href="faq.html">FAQ / Support</a>
+    <a class="nav-link" href="about.html">About</a>
+    <button class="nav-link nav-link--icon" type="button" data-cart-toggle aria-expanded="false" aria-controls="cart-panel">
+      <span class="sr-only" data-cart-label>View cart</span>
+      <svg class="nav-link__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <g fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M3.5 4h2.6l1.6 9.2a1 1 0 0 0 1 .8h8.9a1 1 0 0 0 .97-.76L20 7.5H7.1"/>
+          <circle cx="10" cy="18.5" r="1.25"/>
+          <circle cx="17" cy="18.5" r="1.25"/>
+        </g>
+      </svg>
+      <span class="cart-count" data-cart-count>0</span>
+    </button>
+  </nav>
+</header>
+
+<div class="cart-overlay" data-cart-overlay></div>
+<aside class="cart-panel" id="cart-panel" aria-hidden="true" aria-labelledby="cart-panel-title" role="dialog" aria-modal="true">
+  <div class="cart-panel__header">
+    <h2 id="cart-panel-title">Your cart</h2>
+    <button class="cart-panel__close" type="button" data-cart-close aria-label="Close cart">
+      <span aria-hidden="true">×</span>
+    </button>
+  </div>
+  <div class="cart-panel__body" data-cart-items></div>
+  <div class="cart-panel__footer">
+    <div class="cart-panel__total">
+      <span>Total</span>
+      <strong data-cart-total>$0.00</strong>
+    </div>
+    <button class="btn primary cart-panel__checkout" type="button" data-cart-checkout>Checkout</button>
+    <p class="cart-panel__hint muted">Checkout grants instant access to your Harmony Sheets downloads.</p>
+  </div>
+</aside>
+
+<main>
+  <section class="bundle-hero" style="--bundle-accent:#0ea5e9;--bundle-accent-soft:rgba(14,165,233,0.2)">
+    <span class="bundle-hero__badge">Life Harmony</span>
+    <h1>Full Life Hack Bundle</h1>
+    <p class="bundle-hero__tagline">Transform every area of your Life Harmony Wheel with coordinated systems.</p>
+    <div class="bundle-hero__meta">
+      <span class="bundle-hero__price">$159</span>
+      <span class="bundle-hero__savings">Save $58</span>
+    </div>
+    <p class="bundle-hero__description">Design the rituals, dashboards, and reflections that anchor relationships, career, health, joy, and spirituality. Full Life Hack gives you an all-in-one suite for whole-life alignment.</p>
+    <div class="bundle-hero__cta">
+      <a class="btn primary" href="https://buy.stripe.com/test_fulllifehack" target="_blank" rel="noopener">Unlock the bundle</a>
+      <a class="btn ghost" href="bundles.html">Back to all bundles</a>
+    </div>
+  </section>
+
+  <section class="bundle-section">
+    <div class="bundle-section__inner">
+      <div class="bundle-section__main">
+        <h2>What&#8217;s inside</h2>
+        <ul class="bundle-modules">
+          <li>
+            <h3>Relationship Ritual Tracker</h3>
+            <p>Stay present with the people who matter using shared rituals, connection prompts, and celebration logs.</p>
+          </li>
+          <li>
+            <h3>Career OKR Planner</h3>
+            <p>Set quarterly objectives, track key results, and capture wins so your growth path is crystal clear.</p>
+          </li>
+          <li>
+            <h3>Holistic Health Notebook</h3>
+            <p>Bring workouts, nutrition, sleep, and recovery data into one mindful check-in space.</p>
+          </li>
+          <li>
+            <h3>Joy &amp; Recreation Logbook</h3>
+            <p>Plan adventures, hobbies, and micro-joys so fun receives the same intentional energy as work.</p>
+          </li>
+          <li>
+            <h3>Spiritual Reflection Journal</h3>
+            <p>Integrate gratitude, meditation, and purpose reflections with gentle prompts that guide inner work.</p>
+          </li>
+        </ul>
+      </div>
+      <aside class="bundle-section__aside">
+        <div class="bundle-highlight">
+          <h3>Perfect for</h3>
+          <ul class="bundle-highlight__list">
+            <li>Multi-passionate creators designing a life-first operating system</li>
+            <li>Couples or families who want a shared ritual and planning hub</li>
+            <li>Anyone craving balance across the full Life Harmony Wheel</li>
+          </ul>
+        </div>
+        <div class="bundle-highlight">
+          <h3>Bundle savings</h3>
+          <p>Purchased separately these templates cost $217. Full Life Hack delivers everything for $159 so you keep $58 for experiences that spark joy.</p>
+        </div>
+      </aside>
+    </div>
+  </section>
+
+  <section class="bundle-section">
+    <div class="bundle-section__inner">
+      <div class="bundle-section__main">
+        <h2>Design your life in harmony</h2>
+        <p>Full Life Hack is your ritual companion, decision dashboard, and celebration log. Every template is crafted to talk to the others so you can notice patterns and course-correct quickly.</p>
+        <ul class="bundle-points">
+          <li>
+            <strong>Align your routines.</strong>
+            See how daily habits reinforce long-term intentions across health, relationships, finances, and purpose.
+          </li>
+          <li>
+            <strong>Celebrate progress often.</strong>
+            Track wins, gratitude, and recreation so your nervous system remembers the good alongside the growth edges.
+          </li>
+          <li>
+            <strong>Spot imbalance early.</strong>
+            Use overview dashboards to see which life area needs attention before burnout or resentment creeps in.
+          </li>
+        </ul>
+      </div>
+      <aside class="bundle-section__aside">
+        <div class="bundle-highlight">
+          <h3>Guided onboarding</h3>
+          <p>Follow the included weekly reflection prompts to connect each template and establish your first 30-day rhythm.</p>
+        </div>
+        <div class="bundle-highlight">
+          <h3>Formats</h3>
+          <p>Built for Google Sheets with color-coded views, thoughtful automation, and mobile-friendly dashboards.</p>
+        </div>
+      </aside>
+    </div>
+  </section>
+
+  <section class="bundle-section bundle-section--cta">
+    <div class="bundle-section__inner">
+      <div class="bundle-cta-panel" style="--bundle-accent:#0ea5e9;--bundle-accent-soft:rgba(14,165,233,0.2)">
+        <div>
+          <h2>Live intentionally across every sphere</h2>
+          <p>Build rituals, make confident decisions, and feel the harmony that comes from systems designed for your whole self.</p>
+        </div>
+        <a class="btn primary" href="https://buy.stripe.com/test_fulllifehack" target="_blank" rel="noopener">Unlock Full Life Hack Bundle</a>
+      </div>
+    </div>
+  </section>
+</main>
+
+<footer class="site-footer">
+  <div class="site-footer__inner">
+    <div class="site-footer__grid">
+      <div class="site-footer__column">
+        <h3 class="site-footer__heading">Customer Support</h3>
+        <ul class="site-footer__links">
+          <li><a href="faq.html#guides">Information Guides</a></li>
+          <li><a href="faq.html">FAQ / Support</a></li>
+          <li><a href="faq.html#contact">Contact Us</a></li>
+        </ul>
+      </div>
+      <div class="site-footer__column">
+        <h3 class="site-footer__heading">Policies</h3>
+        <ul class="site-footer__links">
+          <li><a href="policies.html#privacy">Privacy Policy</a></li>
+          <li><a href="policies.html#delivery">Delivery Policy</a></li>
+          <li><a href="policies.html#refund">Refund Policy</a></li>
+          <li><a href="policies.html#terms">Terms of Service</a></li>
+        </ul>
+      </div>
+      <div class="site-footer__column">
+        <h3 class="site-footer__heading">Affiliate</h3>
+        <ul class="site-footer__links">
+          <li><a href="affiliate.html#apply">Become an Affiliate</a></li>
+          <li><a href="affiliate.html#login">Affiliate Login</a></li>
+        </ul>
+      </div>
+      <div class="site-footer__column site-footer__column--newsletter">
+        <h3 class="site-footer__heading">Social &amp; Newsletter</h3>
+        <form id="footer-newsletter" class="footer-form">
+          <label class="sr-only" for="footer-email">Email address</label>
+          <div class="footer-form__controls">
+            <input id="footer-email" type="email" name="email" placeholder="Enter email" required>
+            <button type="submit" class="footer-form__submit">Join</button>
+          </div>
+        </form>
+        <p class="site-footer__note">Subscribe to receive exclusive releases, deals, and event updates.</p>
+        <div class="site-footer__social">
+          <a class="site-footer__social-link" href="https://www.instagram.com/harmonysheets" target="_blank" rel="noopener" aria-label="Instagram">
+            <span aria-hidden="true">IG</span>
+          </a>
+          <a class="site-footer__social-link" href="https://www.youtube.com/@HarmonySheets" target="_blank" rel="noopener" aria-label="YouTube">
+            <span aria-hidden="true">YT</span>
+          </a>
+          <a class="site-footer__social-link" href="https://www.pinterest.com/harmonysheets" target="_blank" rel="noopener" aria-label="Pinterest">
+            <span aria-hidden="true">PI</span>
+          </a>
+          <a class="site-footer__social-link" href="mailto:support@harmony-sheets.com" aria-label="Email Harmony Sheets">
+            <span aria-hidden="true">@</span>
+          </a>
+        </div>
+        <p id="footer-newsletter-status" class="site-footer__status" role="status" aria-live="polite"></p>
+      </div>
+    </div>
+    <div class="site-footer__bottom">
+      <div class="site-footer__brand">
+        <a class="brand brand--footer" href="/">Harmony Sheets</a>
+        <p class="site-footer__copy">© <span id="year"></span> Harmony Sheets. All rights reserved.</p>
+        <p class="site-footer__tagline">One-time purchase. No subscriptions.</p>
+      </div>
+      <div class="site-footer__extras">
+        <p class="site-footer__locale">Serving customers worldwide • USD</p>
+        <div class="site-footer__payments">
+          <span class="site-footer__payment">Visa</span>
+          <span class="site-footer__payment">Mastercard</span>
+          <span class="site-footer__payment">Amex</span>
+          <span class="site-footer__payment">PayPal</span>
+          <span class="site-footer__payment">Shop Pay</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</footer>
+<script src="app.js"></script>
+</body>
+</html>

--- a/bundle-personal-finance.html
+++ b/bundle-personal-finance.html
@@ -1,0 +1,249 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Personal Finance Bundle — Harmony Sheets</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="theme-neutral page-bundle">
+<header class="site-header">
+  <a class="brand" href="/">
+    <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
+    <span>Harmony Sheets</span>
+  </a>
+  <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">
+    <span class="sr-only">Toggle navigation</span>
+    <span class="nav-toggle__icon" aria-hidden="true"></span>
+  </button>
+  <nav class="main-nav" id="site-menu">
+    <div class="nav-item nav-item--browse">
+      <a class="nav-link nav-link--browse" href="products.html" aria-haspopup="true" aria-expanded="false">Discover Life Harmony Apps/Templates</a>
+      <div class="nav-mega" role="menu" aria-label="Life Harmony categories">
+        <div class="nav-mega__content" data-nav-mega-content>
+          <p class="nav-mega__placeholder">Loading Life Harmony areas…</p>
+        </div>
+      </div>
+    </div>
+    <div class="nav-item nav-item--bundles">
+      <a class="nav-link nav-link--bundles" href="bundles.html" aria-haspopup="true" aria-expanded="false">Bundles</a>
+      <div class="nav-flyout" role="menu" aria-label="Featured bundles">
+        <div class="nav-flyout__content" data-nav-bundles>
+          <p class="nav-flyout__placeholder">Loading bundles…</p>
+        </div>
+      </div>
+    </div>
+    <a class="nav-link" href="faq.html">FAQ / Support</a>
+    <a class="nav-link" href="about.html">About</a>
+    <button class="nav-link nav-link--icon" type="button" data-cart-toggle aria-expanded="false" aria-controls="cart-panel">
+      <span class="sr-only" data-cart-label>View cart</span>
+      <svg class="nav-link__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <g fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M3.5 4h2.6l1.6 9.2a1 1 0 0 0 1 .8h8.9a1 1 0 0 0 .97-.76L20 7.5H7.1"/>
+          <circle cx="10" cy="18.5" r="1.25"/>
+          <circle cx="17" cy="18.5" r="1.25"/>
+        </g>
+      </svg>
+      <span class="cart-count" data-cart-count>0</span>
+    </button>
+  </nav>
+</header>
+
+<div class="cart-overlay" data-cart-overlay></div>
+<aside class="cart-panel" id="cart-panel" aria-hidden="true" aria-labelledby="cart-panel-title" role="dialog" aria-modal="true">
+  <div class="cart-panel__header">
+    <h2 id="cart-panel-title">Your cart</h2>
+    <button class="cart-panel__close" type="button" data-cart-close aria-label="Close cart">
+      <span aria-hidden="true">×</span>
+    </button>
+  </div>
+  <div class="cart-panel__body" data-cart-items></div>
+  <div class="cart-panel__footer">
+    <div class="cart-panel__total">
+      <span>Total</span>
+      <strong data-cart-total>$0.00</strong>
+    </div>
+    <button class="btn primary cart-panel__checkout" type="button" data-cart-checkout>Checkout</button>
+    <p class="cart-panel__hint muted">Checkout grants instant access to your Harmony Sheets downloads.</p>
+  </div>
+</aside>
+
+<main>
+  <section class="bundle-hero" style="--bundle-accent:#22c55e;--bundle-accent-soft:rgba(34,197,94,0.22)">
+    <span class="bundle-hero__badge">Money Clarity</span>
+    <h1>Personal Finance Bundle</h1>
+    <p class="bundle-hero__tagline">Master budgets, goals, and spending with calm, visual dashboards.</p>
+    <div class="bundle-hero__meta">
+      <span class="bundle-hero__price">$69</span>
+      <span class="bundle-hero__savings">Save $24</span>
+    </div>
+    <p class="bundle-hero__description">See your entire financial picture in one place. The Personal Finance Bundle unites daily spending, monthly cash flow, long-term goals, and debt payoff into a confident money rhythm.</p>
+    <div class="bundle-hero__cta">
+      <a class="btn primary" href="https://buy.stripe.com/test_personalfinance" target="_blank" rel="noopener">Unlock the bundle</a>
+      <a class="btn ghost" href="bundles.html">Back to all bundles</a>
+    </div>
+  </section>
+
+  <section class="bundle-section">
+    <div class="bundle-section__inner">
+      <div class="bundle-section__main">
+        <h2>What&#8217;s inside</h2>
+        <ul class="bundle-modules">
+          <li>
+            <h3>Annual Budget HQ</h3>
+            <p>Plan your year at a glance with category targets, seasonality adjustments, and progress tracking.</p>
+          </li>
+          <li>
+            <h3>Monthly Cash Flow Radar</h3>
+            <p>Watch income, bills, and variable spending as they land so you never wonder where the money went.</p>
+          </li>
+          <li>
+            <h3>Savings Goal Tracker</h3>
+            <p>Set timelines for emergency funds, travel, or big purchases and watch contributions climb in real time.</p>
+          </li>
+          <li>
+            <h3>Debt Payoff Momentum Map</h3>
+            <p>Visualize balances, snowball/avalanche strategies, and payoff dates to stay motivated.</p>
+          </li>
+        </ul>
+      </div>
+      <aside class="bundle-section__aside">
+        <div class="bundle-highlight">
+          <h3>Perfect for</h3>
+          <ul class="bundle-highlight__list">
+            <li>Households wanting a shared budget that feels calm, not chaotic</li>
+            <li>Early-stage entrepreneurs balancing personal and business expenses</li>
+            <li>Anyone paying down debt while building savings goals</li>
+          </ul>
+        </div>
+        <div class="bundle-highlight">
+          <h3>Bundle savings</h3>
+          <p>Each template purchased alone totals $93. The Personal Finance Bundle wraps them together for $69 so you keep $24 for your next transfer.</p>
+        </div>
+      </aside>
+    </div>
+  </section>
+
+  <section class="bundle-section">
+    <div class="bundle-section__inner">
+      <div class="bundle-section__main">
+        <h2>Make confident money moves</h2>
+        <p>Whether you&#8217;re mapping the month or forecasting the year, the bundle keeps your data connected so decisions are obvious instead of overwhelming.</p>
+        <ul class="bundle-points">
+          <li>
+            <strong>See cash flow clearly.</strong>
+            Color-coded dashboards flag when spending categories drift so you can rebalance quickly.
+          </li>
+          <li>
+            <strong>Celebrate every milestone.</strong>
+            Watch savings meters fill and debt balances shrink with encouraging visuals that reward consistency.
+          </li>
+          <li>
+            <strong>Plan for what&#8217;s next.</strong>
+            Model scenarios, redirect extra cash, and align your goals with the rest of your Life Harmony systems.
+          </li>
+        </ul>
+      </div>
+      <aside class="bundle-section__aside">
+        <div class="bundle-highlight">
+          <h3>Quick start</h3>
+          <p>Import last month&#8217;s transactions and the dashboards will give you instant insight within minutes.</p>
+        </div>
+        <div class="bundle-highlight">
+          <h3>Formats</h3>
+          <p>Optimized for Google Sheets with automation helpers, smart drop-downs, and tap-friendly mobile layouts.</p>
+        </div>
+      </aside>
+    </div>
+  </section>
+
+  <section class="bundle-section bundle-section--cta">
+    <div class="bundle-section__inner">
+      <div class="bundle-cta-panel" style="--bundle-accent:#22c55e;--bundle-accent-soft:rgba(34,197,94,0.22)">
+        <div>
+          <h2>Feel calm with every dollar</h2>
+          <p>Bring clarity to your money decisions and build momentum toward the life you want with aligned finance systems.</p>
+        </div>
+        <a class="btn primary" href="https://buy.stripe.com/test_personalfinance" target="_blank" rel="noopener">Unlock Personal Finance Bundle</a>
+      </div>
+    </div>
+  </section>
+</main>
+
+<footer class="site-footer">
+  <div class="site-footer__inner">
+    <div class="site-footer__grid">
+      <div class="site-footer__column">
+        <h3 class="site-footer__heading">Customer Support</h3>
+        <ul class="site-footer__links">
+          <li><a href="faq.html#guides">Information Guides</a></li>
+          <li><a href="faq.html">FAQ / Support</a></li>
+          <li><a href="faq.html#contact">Contact Us</a></li>
+        </ul>
+      </div>
+      <div class="site-footer__column">
+        <h3 class="site-footer__heading">Policies</h3>
+        <ul class="site-footer__links">
+          <li><a href="policies.html#privacy">Privacy Policy</a></li>
+          <li><a href="policies.html#delivery">Delivery Policy</a></li>
+          <li><a href="policies.html#refund">Refund Policy</a></li>
+          <li><a href="policies.html#terms">Terms of Service</a></li>
+        </ul>
+      </div>
+      <div class="site-footer__column">
+        <h3 class="site-footer__heading">Affiliate</h3>
+        <ul class="site-footer__links">
+          <li><a href="affiliate.html#apply">Become an Affiliate</a></li>
+          <li><a href="affiliate.html#login">Affiliate Login</a></li>
+        </ul>
+      </div>
+      <div class="site-footer__column site-footer__column--newsletter">
+        <h3 class="site-footer__heading">Social &amp; Newsletter</h3>
+        <form id="footer-newsletter" class="footer-form">
+          <label class="sr-only" for="footer-email">Email address</label>
+          <div class="footer-form__controls">
+            <input id="footer-email" type="email" name="email" placeholder="Enter email" required>
+            <button type="submit" class="footer-form__submit">Join</button>
+          </div>
+        </form>
+        <p class="site-footer__note">Subscribe to receive exclusive releases, deals, and event updates.</p>
+        <div class="site-footer__social">
+          <a class="site-footer__social-link" href="https://www.instagram.com/harmonysheets" target="_blank" rel="noopener" aria-label="Instagram">
+            <span aria-hidden="true">IG</span>
+          </a>
+          <a class="site-footer__social-link" href="https://www.youtube.com/@HarmonySheets" target="_blank" rel="noopener" aria-label="YouTube">
+            <span aria-hidden="true">YT</span>
+          </a>
+          <a class="site-footer__social-link" href="https://www.pinterest.com/harmonysheets" target="_blank" rel="noopener" aria-label="Pinterest">
+            <span aria-hidden="true">PI</span>
+          </a>
+          <a class="site-footer__social-link" href="mailto:support@harmony-sheets.com" aria-label="Email Harmony Sheets">
+            <span aria-hidden="true">@</span>
+          </a>
+        </div>
+        <p id="footer-newsletter-status" class="site-footer__status" role="status" aria-live="polite"></p>
+      </div>
+    </div>
+    <div class="site-footer__bottom">
+      <div class="site-footer__brand">
+        <a class="brand brand--footer" href="/">Harmony Sheets</a>
+        <p class="site-footer__copy">© <span id="year"></span> Harmony Sheets. All rights reserved.</p>
+        <p class="site-footer__tagline">One-time purchase. No subscriptions.</p>
+      </div>
+      <div class="site-footer__extras">
+        <p class="site-footer__locale">Serving customers worldwide • USD</p>
+        <div class="site-footer__payments">
+          <span class="site-footer__payment">Visa</span>
+          <span class="site-footer__payment">Mastercard</span>
+          <span class="site-footer__payment">Amex</span>
+          <span class="site-footer__payment">PayPal</span>
+          <span class="site-footer__payment">Shop Pay</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</footer>
+<script src="app.js"></script>
+</body>
+</html>

--- a/bundle-premium.html
+++ b/bundle-premium.html
@@ -1,0 +1,249 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Premium Bundle — Harmony Sheets</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="theme-neutral page-bundle">
+<header class="site-header">
+  <a class="brand" href="/">
+    <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
+    <span>Harmony Sheets</span>
+  </a>
+  <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">
+    <span class="sr-only">Toggle navigation</span>
+    <span class="nav-toggle__icon" aria-hidden="true"></span>
+  </button>
+  <nav class="main-nav" id="site-menu">
+    <div class="nav-item nav-item--browse">
+      <a class="nav-link nav-link--browse" href="products.html" aria-haspopup="true" aria-expanded="false">Discover Life Harmony Apps/Templates</a>
+      <div class="nav-mega" role="menu" aria-label="Life Harmony categories">
+        <div class="nav-mega__content" data-nav-mega-content>
+          <p class="nav-mega__placeholder">Loading Life Harmony areas…</p>
+        </div>
+      </div>
+    </div>
+    <div class="nav-item nav-item--bundles">
+      <a class="nav-link nav-link--bundles" href="bundles.html" aria-haspopup="true" aria-expanded="false">Bundles</a>
+      <div class="nav-flyout" role="menu" aria-label="Featured bundles">
+        <div class="nav-flyout__content" data-nav-bundles>
+          <p class="nav-flyout__placeholder">Loading bundles…</p>
+        </div>
+      </div>
+    </div>
+    <a class="nav-link" href="faq.html">FAQ / Support</a>
+    <a class="nav-link" href="about.html">About</a>
+    <button class="nav-link nav-link--icon" type="button" data-cart-toggle aria-expanded="false" aria-controls="cart-panel">
+      <span class="sr-only" data-cart-label>View cart</span>
+      <svg class="nav-link__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <g fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M3.5 4h2.6l1.6 9.2a1 1 0 0 0 1 .8h8.9a1 1 0 0 0 .97-.76L20 7.5H7.1"/>
+          <circle cx="10" cy="18.5" r="1.25"/>
+          <circle cx="17" cy="18.5" r="1.25"/>
+        </g>
+      </svg>
+      <span class="cart-count" data-cart-count>0</span>
+    </button>
+  </nav>
+</header>
+
+<div class="cart-overlay" data-cart-overlay></div>
+<aside class="cart-panel" id="cart-panel" aria-hidden="true" aria-labelledby="cart-panel-title" role="dialog" aria-modal="true">
+  <div class="cart-panel__header">
+    <h2 id="cart-panel-title">Your cart</h2>
+    <button class="cart-panel__close" type="button" data-cart-close aria-label="Close cart">
+      <span aria-hidden="true">×</span>
+    </button>
+  </div>
+  <div class="cart-panel__body" data-cart-items></div>
+  <div class="cart-panel__footer">
+    <div class="cart-panel__total">
+      <span>Total</span>
+      <strong data-cart-total>$0.00</strong>
+    </div>
+    <button class="btn primary cart-panel__checkout" type="button" data-cart-checkout>Checkout</button>
+    <p class="cart-panel__hint muted">Checkout grants instant access to your Harmony Sheets downloads.</p>
+  </div>
+</aside>
+
+<main>
+  <section class="bundle-hero" style="--bundle-accent:#7c3aed;--bundle-accent-soft:rgba(124,58,237,0.2)">
+    <span class="bundle-hero__badge">Pro Essentials</span>
+    <h1>Premium Bundle</h1>
+    <p class="bundle-hero__tagline">Every flagship Harmony Sheet gathered into a premium toolkit.</p>
+    <div class="bundle-hero__meta">
+      <span class="bundle-hero__price">$119</span>
+      <span class="bundle-hero__savings">Save $42</span>
+    </div>
+    <p class="bundle-hero__description">Streamline your personal HQ, project cockpit, money systems, and deep work rituals with one cohesive suite. The Premium Bundle turns high-performing templates into a synchronized operating system.</p>
+    <div class="bundle-hero__cta">
+      <a class="btn primary" href="https://buy.stripe.com/test_premium" target="_blank" rel="noopener">Unlock the bundle</a>
+      <a class="btn ghost" href="bundles.html">Back to all bundles</a>
+    </div>
+  </section>
+
+  <section class="bundle-section">
+    <div class="bundle-section__inner">
+      <div class="bundle-section__main">
+        <h2>What&#8217;s inside</h2>
+        <ul class="bundle-modules">
+          <li>
+            <h3>Ultimate Habit Operating System</h3>
+            <p>Design daily, weekly, and seasonal rituals with habit scoring, habit stacking, and reset checkpoints to keep growth visible.</p>
+          </li>
+          <li>
+            <h3>Project Command Center</h3>
+            <p>Manage multi-step projects, sprint boards, and resource planning inside a calm control tower that keeps stakeholders aligned.</p>
+          </li>
+          <li>
+            <h3>Executive Finance Console</h3>
+            <p>Bring cash flow, profit tracking, and runway forecasting into one analytics hub built for founders and service providers.</p>
+          </li>
+          <li>
+            <h3>Deep Work Time Blocking Studio</h3>
+            <p>Build weekly focus maps with intention tags, distraction safeguards, and review prompts to protect meaningful work.</p>
+          </li>
+        </ul>
+      </div>
+      <aside class="bundle-section__aside">
+        <div class="bundle-highlight">
+          <h3>Perfect for</h3>
+          <ul class="bundle-highlight__list">
+            <li>Solopreneurs and operators leading across many responsibilities</li>
+            <li>Creators leveling up their systems for client delivery and personal brand</li>
+            <li>High achievers who want one streamlined HQ for life and business</li>
+          </ul>
+        </div>
+        <div class="bundle-highlight">
+          <h3>Bundle savings</h3>
+          <p>Separately these premium templates add up to $161. Bundle them for $119 and reinvest the $42 savings into strategy sessions or tooling.</p>
+        </div>
+      </aside>
+    </div>
+  </section>
+
+  <section class="bundle-section">
+    <div class="bundle-section__inner">
+      <div class="bundle-section__main">
+        <h2>Build a powerhouse HQ</h2>
+        <p>When habit systems, project planning, finances, and deep work rhythms speak to each other you gain clarity fast. The Premium Bundle gives you dashboards that surface the right metrics automatically.</p>
+        <ul class="bundle-points">
+          <li>
+            <strong>Connect goals to execution.</strong>
+            Map quarterly priorities to weekly focus sessions and track velocity across every workstream.
+          </li>
+          <li>
+            <strong>Operate with financial confidence.</strong>
+            Review revenue, expenses, and runway in real time so you can make decisive moves without spreadsheet chaos.
+          </li>
+          <li>
+            <strong>Protect your energy.</strong>
+            Schedule deep work, recovery, and admin blocks with clear guardrails and post-session reflections.
+          </li>
+        </ul>
+      </div>
+      <aside class="bundle-section__aside">
+        <div class="bundle-highlight">
+          <h3>Quick deployment</h3>
+          <p>Duplicate the command center, connect your existing task list, and link it to the finance console in less than an hour.</p>
+        </div>
+        <div class="bundle-highlight">
+          <h3>Formats</h3>
+          <p>All templates are optimized for Google Sheets with interactive toggles, smart filters, and automation-ready structures.</p>
+        </div>
+      </aside>
+    </div>
+  </section>
+
+  <section class="bundle-section bundle-section--cta">
+    <div class="bundle-section__inner">
+      <div class="bundle-cta-panel" style="--bundle-accent:#7c3aed;--bundle-accent-soft:rgba(124,58,237,0.2)">
+        <div>
+          <h2>Lead with clarity and momentum</h2>
+          <p>Upgrade to one cohesive system that keeps your habits, projects, and money aligned so you can scale with calm confidence.</p>
+        </div>
+        <a class="btn primary" href="https://buy.stripe.com/test_premium" target="_blank" rel="noopener">Unlock Premium Bundle</a>
+      </div>
+    </div>
+  </section>
+</main>
+
+<footer class="site-footer">
+  <div class="site-footer__inner">
+    <div class="site-footer__grid">
+      <div class="site-footer__column">
+        <h3 class="site-footer__heading">Customer Support</h3>
+        <ul class="site-footer__links">
+          <li><a href="faq.html#guides">Information Guides</a></li>
+          <li><a href="faq.html">FAQ / Support</a></li>
+          <li><a href="faq.html#contact">Contact Us</a></li>
+        </ul>
+      </div>
+      <div class="site-footer__column">
+        <h3 class="site-footer__heading">Policies</h3>
+        <ul class="site-footer__links">
+          <li><a href="policies.html#privacy">Privacy Policy</a></li>
+          <li><a href="policies.html#delivery">Delivery Policy</a></li>
+          <li><a href="policies.html#refund">Refund Policy</a></li>
+          <li><a href="policies.html#terms">Terms of Service</a></li>
+        </ul>
+      </div>
+      <div class="site-footer__column">
+        <h3 class="site-footer__heading">Affiliate</h3>
+        <ul class="site-footer__links">
+          <li><a href="affiliate.html#apply">Become an Affiliate</a></li>
+          <li><a href="affiliate.html#login">Affiliate Login</a></li>
+        </ul>
+      </div>
+      <div class="site-footer__column site-footer__column--newsletter">
+        <h3 class="site-footer__heading">Social &amp; Newsletter</h3>
+        <form id="footer-newsletter" class="footer-form">
+          <label class="sr-only" for="footer-email">Email address</label>
+          <div class="footer-form__controls">
+            <input id="footer-email" type="email" name="email" placeholder="Enter email" required>
+            <button type="submit" class="footer-form__submit">Join</button>
+          </div>
+        </form>
+        <p class="site-footer__note">Subscribe to receive exclusive releases, deals, and event updates.</p>
+        <div class="site-footer__social">
+          <a class="site-footer__social-link" href="https://www.instagram.com/harmonysheets" target="_blank" rel="noopener" aria-label="Instagram">
+            <span aria-hidden="true">IG</span>
+          </a>
+          <a class="site-footer__social-link" href="https://www.youtube.com/@HarmonySheets" target="_blank" rel="noopener" aria-label="YouTube">
+            <span aria-hidden="true">YT</span>
+          </a>
+          <a class="site-footer__social-link" href="https://www.pinterest.com/harmonysheets" target="_blank" rel="noopener" aria-label="Pinterest">
+            <span aria-hidden="true">PI</span>
+          </a>
+          <a class="site-footer__social-link" href="mailto:support@harmony-sheets.com" aria-label="Email Harmony Sheets">
+            <span aria-hidden="true">@</span>
+          </a>
+        </div>
+        <p id="footer-newsletter-status" class="site-footer__status" role="status" aria-live="polite"></p>
+      </div>
+    </div>
+    <div class="site-footer__bottom">
+      <div class="site-footer__brand">
+        <a class="brand brand--footer" href="/">Harmony Sheets</a>
+        <p class="site-footer__copy">© <span id="year"></span> Harmony Sheets. All rights reserved.</p>
+        <p class="site-footer__tagline">One-time purchase. No subscriptions.</p>
+      </div>
+      <div class="site-footer__extras">
+        <p class="site-footer__locale">Serving customers worldwide • USD</p>
+        <div class="site-footer__payments">
+          <span class="site-footer__payment">Visa</span>
+          <span class="site-footer__payment">Mastercard</span>
+          <span class="site-footer__payment">Amex</span>
+          <span class="site-footer__payment">PayPal</span>
+          <span class="site-footer__payment">Shop Pay</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</footer>
+<script src="app.js"></script>
+</body>
+</html>

--- a/bundles.json
+++ b/bundles.json
@@ -10,6 +10,7 @@
     "category": "planning",
     "color": "#2563eb",
     "navFeatured": true,
+    "page": "bundle-back-to-school.html",
     "stripe_link": "https://buy.stripe.com/test_backtoschool",
     "includes": [
       "Semester Course Planner",
@@ -17,7 +18,7 @@
       "Weekly Study Schedule",
       "Student Budget Snapshot"
     ],
-    "cta": "Preview bundle"
+    "cta": "View bundle details"
   },
   {
     "slug": "premium",
@@ -30,6 +31,7 @@
     "category": "productivity",
     "color": "#7c3aed",
     "navFeatured": true,
+    "page": "bundle-premium.html",
     "stripe_link": "https://buy.stripe.com/test_premium",
     "includes": [
       "Ultimate Habit Operating System",
@@ -37,7 +39,7 @@
       "Executive Finance Console",
       "Deep Work Time Blocking Studio"
     ],
-    "cta": "Unlock premium bundle"
+    "cta": "View bundle details"
   },
   {
     "slug": "full-life-hack",
@@ -50,6 +52,7 @@
     "category": "lifestyle",
     "color": "#0ea5e9",
     "navFeatured": true,
+    "page": "bundle-full-life-hack.html",
     "stripe_link": "https://buy.stripe.com/test_fulllifehack",
     "includes": [
       "Relationship Ritual Tracker",
@@ -58,7 +61,7 @@
       "Joy & Recreation Logbook",
       "Spiritual Reflection Journal"
     ],
-    "cta": "Explore the full bundle"
+    "cta": "View bundle details"
   },
   {
     "slug": "personal-finance",
@@ -71,6 +74,7 @@
     "category": "finance",
     "color": "#22c55e",
     "navFeatured": true,
+    "page": "bundle-personal-finance.html",
     "stripe_link": "https://buy.stripe.com/test_personalfinance",
     "includes": [
       "Annual Budget HQ",
@@ -78,6 +82,6 @@
       "Savings Goal Tracker",
       "Debt Payoff Momentum Map"
     ],
-    "cta": "Start budgeting smarter"
+    "cta": "View bundle details"
   }
 ]

--- a/style.css
+++ b/style.css
@@ -98,16 +98,24 @@ button.nav-link{border:0;background:transparent;cursor:pointer;font:inherit}
 .nav-item--bundles{position:relative}
 .nav-link--bundles::after{content:"▾";font-size:.68em;margin-left:6px;transition:transform .2s ease}
 .nav-item--bundles.is-open>.nav-link--bundles::after,.nav-item--bundles:hover>.nav-link--bundles::after{transform:rotate(180deg)}
-.nav-flyout{position:absolute;top:calc(100% + 14px);left:50%;width:min(360px,calc(100vw - 48px));background:rgba(255,255,255,.98);border-radius:20px;border:1px solid rgba(148,163,184,.26);box-shadow:0 28px 60px rgba(15,23,42,.16);padding:20px;opacity:0;pointer-events:none;visibility:hidden;transform:translate3d(-50%,10px,0);transition:opacity .2s ease,transform .2s ease,visibility .2s ease;z-index:70}
+.nav-flyout{position:absolute;top:calc(100% + 14px);left:50%;width:min(1080px,calc(100vw - 48px));background:rgba(255,255,255,.98);border-radius:22px;border:1px solid rgba(148,163,184,.26);box-shadow:0 28px 60px rgba(15,23,42,.16);padding:24px;opacity:0;pointer-events:none;visibility:hidden;transform:translate3d(-50%,10px,0);transition:opacity .2s ease,transform .2s ease,visibility .2s ease;z-index:70}
 .nav-item--bundles:hover .nav-flyout,.nav-item--bundles:focus-within .nav-flyout,.nav-item--bundles.is-open .nav-flyout{opacity:1;pointer-events:auto;visibility:visible;transform:translate3d(-50%,0,0)}
-.nav-flyout__content{display:grid;gap:16px}
-.nav-bundles{display:grid;gap:10px}
-.nav-bundles__link{position:relative;display:flex;flex-direction:column;gap:4px;padding:12px 14px 12px 20px;border-radius:14px;border:1px solid rgba(148,163,184,.18);background:linear-gradient(160deg,var(--bundle-accent-soft,rgba(99,102,241,.15)) 0%,rgba(255,255,255,.96) 100%);color:#1f2937;font-weight:600;box-shadow:0 12px 26px rgba(15,23,42,.08);text-decoration:none;transition:transform .2s ease,box-shadow .2s ease,border-color .2s ease}
-.nav-bundles__link::before{content:"";position:absolute;top:12px;bottom:12px;left:10px;width:4px;border-radius:999px;background:var(--bundle-accent,#6366f1);opacity:.9}
-.nav-bundles__link:hover,.nav-bundles__link:focus-visible{transform:translateY(-2px);border-color:var(--bundle-accent,#6366f1);box-shadow:0 18px 40px rgba(15,23,42,.14);outline:none}
-.nav-bundles__title{font-size:1rem;line-height:1.35}
-.nav-bundles__desc{font-size:.88rem;color:#475569;font-weight:500}
-.nav-flyout__footer{display:flex;justify-content:flex-start;padding-top:8px;border-top:1px solid rgba(148,163,184,.2)}
+.nav-flyout__content{display:grid;gap:18px}
+.nav-bundles-grid{display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:18px;max-width:960px;margin:0 auto}
+.nav-bundle-card{display:flex;flex-direction:column;gap:10px;padding:18px 18px 20px;border-radius:18px;border:1px solid rgba(148,163,184,.18);background:linear-gradient(180deg,var(--bundle-accent-soft,rgba(99,102,241,.16)) 0%,#fff 58%);color:#0f172a;text-decoration:none;box-shadow:0 20px 44px rgba(15,23,42,.08);transition:transform .2s ease,box-shadow .2s ease,border-color .2s ease}
+.nav-bundle-card:hover,.nav-bundle-card:focus-visible{transform:translateY(-3px);border-color:var(--bundle-accent,#6366f1);box-shadow:0 28px 60px rgba(15,23,42,.15);outline:none}
+.nav-bundle-card__badge{display:inline-flex;align-items:center;gap:6px;padding:6px 12px;border-radius:999px;background:var(--bundle-accent,#6366f1);color:#fff;font-size:.75rem;font-weight:600;letter-spacing:.04em;text-transform:uppercase;box-shadow:0 10px 24px color-mix(in srgb,var(--bundle-accent) 32%,transparent)}
+.nav-bundle-card__title{font-size:1.08rem;font-weight:700}
+.nav-bundle-card__tagline{font-size:.92rem;color:#475569}
+.nav-bundle-card__pricing{display:flex;align-items:center;gap:10px;font-size:.95rem;color:#0f172a}
+.nav-bundle-card__pricing strong{font-weight:700}
+.nav-bundle-card__pricing em{font-style:normal;font-weight:600;color:#15803d;background:rgba(34,197,94,.14);padding:3px 8px;border-radius:999px}
+.nav-bundle-card__includes{list-style:none;margin:4px 0 0;padding:0;display:grid;gap:6px;font-size:.85rem;color:#374151}
+.nav-bundle-card__includes li{position:relative;padding-left:16px}
+.nav-bundle-card__includes li::before{content:"•";position:absolute;left:0;top:0;color:var(--bundle-accent,#6366f1);font-weight:700}
+.nav-bundle-card__cta{margin-top:auto;display:inline-flex;align-items:center;justify-content:flex-start;gap:6px;font-size:.9rem;font-weight:600;color:var(--bundle-accent,#1d4ed8)}
+.nav-bundle-card__cta::after{content:"→";font-size:.95rem;transform:translateY(-1px)}
+.nav-flyout__footer{display:flex;justify-content:center;padding-top:12px;border-top:1px solid rgba(148,163,184,.2)}
 .nav-flyout__footer a{font-weight:600;color:#1d4ed8}
 .nav-flyout__placeholder{margin:0;color:#475569;font-size:.92rem}
 .cart-overlay{position:fixed;inset:0;background:rgba(15,23,42,.38);opacity:0;pointer-events:none;transition:opacity .2s ease;z-index:70}
@@ -315,6 +323,57 @@ body[class*="theme-midnight"]{
 .bundle-card.is-highlighted{border-color:var(--bundle-accent,#1d4ed8);box-shadow:0 0 0 4px var(--bundle-accent-soft,rgba(99,102,241,.22)),0 32px 64px rgba(15,23,42,.2);transform:translateY(-4px)}
 .bundles-empty{grid-column:1/-1;margin:0;padding:36px;border-radius:18px;border:1px dashed rgba(148,163,184,.4);background:rgba(248,250,252,.82);text-align:center;color:#475569;font-size:.95rem}
 .price{font-weight:700;margin:8px 0}
+
+body.page-bundle main{max-width:1120px;margin:0 auto;padding:48px 18px 80px;display:grid;gap:64px}
+.bundle-hero{background:linear-gradient(140deg,var(--bundle-accent-soft,rgba(99,102,241,.16)) 0%,rgba(255,255,255,.97) 100%);border:1px solid rgba(148,163,184,.24);border-radius:28px;padding:42px 48px;box-shadow:0 32px 72px rgba(15,23,42,.14);display:grid;gap:18px;color:#0f172a}
+.bundle-hero__badge{display:inline-flex;align-items:center;gap:6px;padding:6px 14px;border-radius:999px;background:var(--bundle-accent,#1d4ed8);color:#fff;font-weight:600;letter-spacing:.05em;text-transform:uppercase;font-size:.78rem;box-shadow:0 18px 40px color-mix(in srgb,var(--bundle-accent) 26%,transparent)}
+.bundle-hero h1{margin:0;font-size:2.6rem;line-height:1.1}
+.bundle-hero__tagline{margin:0;font-size:1.12rem;color:#334155;max-width:720px}
+.bundle-hero__meta{display:flex;align-items:center;gap:14px;font-size:1.05rem;font-weight:600}
+.bundle-hero__price{font-size:1.4rem;font-weight:700}
+.bundle-hero__savings{display:inline-flex;align-items:center;gap:6px;padding:6px 12px;border-radius:999px;background:rgba(34,197,94,.16);color:#15803d;font-size:.9rem;font-weight:600}
+.bundle-hero__description{margin:0;max-width:760px;color:#1f2937;font-size:1.02rem}
+.bundle-hero__cta{display:flex;gap:12px;flex-wrap:wrap;margin-top:6px}
+
+.bundle-section{display:block}
+.bundle-section__inner{display:grid;grid-template-columns:minmax(0,1fr) 320px;gap:36px;align-items:start}
+.bundle-section__main>h2{margin-top:0;font-size:1.9rem}
+.bundle-modules{list-style:none;margin:0;padding:0;display:grid;gap:18px}
+.bundle-modules li{padding:20px;border:1px solid rgba(148,163,184,.24);border-radius:18px;background:#fff;box-shadow:0 16px 38px rgba(15,23,42,.08);display:grid;gap:8px}
+.bundle-modules h3{margin:0;font-size:1.15rem;color:#0f172a}
+.bundle-modules p{margin:0;color:#475569;font-size:.97rem}
+.bundle-section__aside{display:grid;gap:18px}
+.bundle-highlight{padding:22px;border-radius:20px;border:1px solid rgba(148,163,184,.2);background:linear-gradient(180deg,rgba(148,163,184,.08) 0%,rgba(255,255,255,.95) 100%);box-shadow:0 24px 54px rgba(15,23,42,.12);display:grid;gap:12px}
+.bundle-highlight h3{margin:0;font-size:1.1rem}
+.bundle-highlight p{margin:0;color:#475569;font-size:.95rem}
+.bundle-highlight__list{list-style:none;margin:0;padding:0;display:grid;gap:8px;color:#1f2937;font-size:.95rem}
+.bundle-highlight__list li{position:relative;padding-left:18px}
+.bundle-highlight__list li::before{content:"✓";position:absolute;left:0;top:0;color:var(--bundle-accent,#1d4ed8);font-weight:700}
+.bundle-points{list-style:none;margin:18px 0 0;padding:0;display:grid;gap:12px;color:#1f2937}
+.bundle-points li{padding-left:0}
+.bundle-points strong{display:block;font-size:1rem;margin-bottom:4px;color:#0f172a}
+.bundle-section--cta .bundle-section__inner{grid-template-columns:1fr}
+.bundle-cta-panel{padding:32px 36px;border-radius:24px;background:linear-gradient(120deg,var(--bundle-accent-soft,rgba(99,102,241,.16)) 0%,#fff 78%);border:1px solid rgba(148,163,184,.22);box-shadow:0 28px 60px rgba(15,23,42,.14);display:flex;flex-wrap:wrap;align-items:center;justify-content:space-between;gap:18px}
+.bundle-cta-panel h2{margin:0;font-size:1.9rem}
+.bundle-cta-panel p{margin:0;color:#334155;font-size:1.02rem;max-width:540px}
+.bundle-cta-panel .btn{padding:12px 24px}
+
+@media(max-width:1024px){
+  .bundle-section__inner{grid-template-columns:1fr}
+  .bundle-section__aside{grid-template-columns:repeat(auto-fit,minmax(260px,1fr))}
+}
+
+@media(max-width:900px){
+  .bundle-hero{padding:32px}
+  .bundle-hero h1{font-size:2.2rem}
+}
+
+@media(max-width:640px){
+  body.page-bundle main{padding:36px 16px 64px}
+  .bundle-hero{padding:28px}
+  .bundle-hero__meta{flex-wrap:wrap}
+  .bundle-cta-panel{padding:28px;flex-direction:column;align-items:flex-start}
+}
 
 .shop{padding:24px;max-width:1100px;margin:0 auto}
 .filters{display:flex;gap:10px;flex-wrap:wrap;margin-bottom:14px}


### PR DESCRIPTION
## Summary
- redesign the desktop bundles navigation flyout with four featured bundle cards and richer content
- update bundle metadata to link to dedicated detail pages and reuse it on the bundles listing
- create tailored landing pages for each bundle with descriptions, inclusions, and focused calls to action

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d5c470249c832d983ed085b0ad0230