### PR TITLE
Add under-construction notice beside site logo

### DIFF
--- a/about.html
+++ b/about.html
@@ -11,7 +11,10 @@
 <header class="site-header">
   <a class="brand" href="/">
     <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
-    <span>Harmony Sheets</span>
+    <span class="brand__text">
+      <span class="brand__name">Harmony Sheets</span>
+      <span class="brand__notice">Site under construction</span>
+    </span>
   </a>
   <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">
     <span class="sr-only">Toggle navigation</span>

--- a/affiliate.html
+++ b/affiliate.html
@@ -11,7 +11,10 @@
 <header class="site-header">
   <a class="brand" href="/">
     <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
-    <span>Harmony Sheets</span>
+    <span class="brand__text">
+      <span class="brand__name">Harmony Sheets</span>
+      <span class="brand__notice">Site under construction</span>
+    </span>
   </a>
   <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">
     <span class="sr-only">Toggle navigation</span>

--- a/bundle-back-to-school.html
+++ b/bundle-back-to-school.html
@@ -11,7 +11,10 @@
 <header class="site-header">
   <a class="brand" href="/">
     <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
-    <span>Harmony Sheets</span>
+    <span class="brand__text">
+      <span class="brand__name">Harmony Sheets</span>
+      <span class="brand__notice">Site under construction</span>
+    </span>
   </a>
   <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">
     <span class="sr-only">Toggle navigation</span>

--- a/bundle-full-life-hack.html
+++ b/bundle-full-life-hack.html
@@ -11,7 +11,10 @@
 <header class="site-header">
   <a class="brand" href="/">
     <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
-    <span>Harmony Sheets</span>
+    <span class="brand__text">
+      <span class="brand__name">Harmony Sheets</span>
+      <span class="brand__notice">Site under construction</span>
+    </span>
   </a>
   <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">
     <span class="sr-only">Toggle navigation</span>

--- a/bundle-personal-finance.html
+++ b/bundle-personal-finance.html
@@ -11,7 +11,10 @@
 <header class="site-header">
   <a class="brand" href="/">
     <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
-    <span>Harmony Sheets</span>
+    <span class="brand__text">
+      <span class="brand__name">Harmony Sheets</span>
+      <span class="brand__notice">Site under construction</span>
+    </span>
   </a>
   <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">
     <span class="sr-only">Toggle navigation</span>

--- a/bundle-premium.html
+++ b/bundle-premium.html
@@ -11,7 +11,10 @@
 <header class="site-header">
   <a class="brand" href="/">
     <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
-    <span>Harmony Sheets</span>
+    <span class="brand__text">
+      <span class="brand__name">Harmony Sheets</span>
+      <span class="brand__notice">Site under construction</span>
+    </span>
   </a>
   <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">
     <span class="sr-only">Toggle navigation</span>

--- a/bundles.html
+++ b/bundles.html
@@ -11,7 +11,10 @@
 <header class="site-header">
   <a class="brand" href="/">
     <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
-    <span>Harmony Sheets</span>
+    <span class="brand__text">
+      <span class="brand__name">Harmony Sheets</span>
+      <span class="brand__notice">Site under construction</span>
+    </span>
   </a>
   <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">
     <span class="sr-only">Toggle navigation</span>

--- a/faq.html
+++ b/faq.html
@@ -11,7 +11,10 @@
 <header class="site-header">
   <a class="brand" href="/">
     <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
-    <span>Harmony Sheets</span>
+    <span class="brand__text">
+      <span class="brand__name">Harmony Sheets</span>
+      <span class="brand__notice">Site under construction</span>
+    </span>
   </a>
   <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">
     <span class="sr-only">Toggle navigation</span>

--- a/index.html
+++ b/index.html
@@ -12,7 +12,10 @@
 <header class="site-header">
   <a class="brand" href="/">
     <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
-    <span>Harmony Sheets</span>
+    <span class="brand__text">
+      <span class="brand__name">Harmony Sheets</span>
+      <span class="brand__notice">Site under construction</span>
+    </span>
   </a>
   <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">
     <span class="sr-only">Toggle navigation</span>

--- a/policies.html
+++ b/policies.html
@@ -11,7 +11,10 @@
 <header class="site-header">
   <a class="brand" href="/">
     <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
-    <span>Harmony Sheets</span>
+    <span class="brand__text">
+      <span class="brand__name">Harmony Sheets</span>
+      <span class="brand__notice">Site under construction</span>
+    </span>
   </a>
   <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">
     <span class="sr-only">Toggle navigation</span>

--- a/product.html
+++ b/product.html
@@ -12,7 +12,10 @@
   <header class="site-header">
     <a class="brand" href="/">
       <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
-      <span>Harmony Sheets</span>
+      <span class="brand__text">
+        <span class="brand__name">Harmony Sheets</span>
+        <span class="brand__notice">Site under construction</span>
+      </span>
     </a>
     <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">
       <span class="sr-only">Toggle navigation</span>

--- a/products.html
+++ b/products.html
@@ -11,7 +11,10 @@
   <header class="site-header">
     <a class="brand" href="/">
       <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
-      <span>Harmony Sheets</span>
+      <span class="brand__text">
+        <span class="brand__name">Harmony Sheets</span>
+        <span class="brand__notice">Site under construction</span>
+      </span>
     </a>
     <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">
       <span class="sr-only">Toggle navigation</span>

--- a/style.css
+++ b/style.css
@@ -22,6 +22,9 @@ img{max-width:100%;display:block}
 .site-header{display:flex;align-items:center;justify-content:space-between;gap:16px;padding:14px 20px;border-bottom:1px solid var(--border);position:sticky;top:0;background:rgba(255,255,255,.96);backdrop-filter:saturate(150%) blur(14px);z-index:60}
 .brand{display:inline-flex;align-items:center;gap:8px;font-weight:700;font-size:1.12rem;letter-spacing:.02em;color:#0f172a;text-decoration:none;transition:color .2s ease}
 .brand__logo{width:48px;height:48px;object-fit:contain;display:block;flex-shrink:0}
+.brand__text{display:flex;flex-direction:column;gap:2px;line-height:1.05}
+.brand__name{font-size:1.12rem;font-weight:700;color:inherit}
+.brand__notice{font-size:.75rem;font-weight:600;color:#dc2626;letter-spacing:.08em;text-transform:uppercase}
 .brand:hover,.brand:focus-visible{color:#1d4ed8}
 .main-nav{display:flex;align-items:center;gap:10px;padding:6px 8px;border-radius:999px;background:rgba(255,255,255,.78);border:1px solid rgba(148,163,184,.22);box-shadow:0 12px 30px rgba(15,23,42,.08);position:relative}
 .nav-item{position:relative}


### PR DESCRIPTION
## Summary
- add an under-construction notice beside the Harmony Sheets logo in the site header across all pages
- style the new notice text to appear smaller, red, and stacked with the brand name

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d79d9ec3a4832db114c7b05a0401a6