### PR TITLE
Tweak hero branding and rename Living Space category

### DIFF
--- a/app.js
+++ b/app.js
@@ -217,14 +217,14 @@ App.LIFE_AREAS = {
     ]
   },
   environment: {
-    title: "Physical Environment",
-    short: "Environment",
+    title: "Living Space",
+    short: "Living Space",
     color: "#14B8A6",
     icon: App.LIFE_ICONS.environment,
     description: "Design supportive spaces, tidy routines, and home projects with clarity.",
     link: "products.html?area=environment",
     cta: "Design your ideal space",
-    empty: "Fresh templates for your environment are on the way. Check out the full library in the meantime.",
+    empty: "Fresh templates for your living space are on the way. Check out the full library in the meantime.",
     menuQuestion: "Ready to refresh the spaces you spend the most time in?",
     menuHighlights: [
       "Room reset routines",

--- a/index.html
+++ b/index.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <title>Harmony Sheets — Calm, App-like Spreadsheets (One-Time Purchase)</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <meta name="description" content="Explore the Life Harmony Wheel — Love, Career, Health, Finances, Fun, Family, Environment, and Spirituality. App-like spreadsheets with one-time pricing.">
+  <meta name="description" content="Explore the Life Harmony Wheel — Love, Career, Health, Finances, Fun, Family, Living Space, and Spirituality. App-like spreadsheets with one-time pricing.">
   <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
   <link rel="stylesheet" href="style.css">
 </head>
@@ -14,7 +14,7 @@
     <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
     <span class="brand__text">
       <span class="brand__name">Harmony Sheets</span>
-      <span class="brand__notice">One-time purchase. No subscriptions. You own the tool.</span>
+      <span class="brand__notice">No subscriptions. You own the tool.</span>
     </span>
   </a>
   <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">
@@ -121,7 +121,7 @@
               <path class="life-wheel__slice" fill="#60A5FA" d="M 180 180 L 66.863 293.137 A 160 160 0 0 1 20.0 180.0 Z"/>
             </a>
             <a class="life-wheel__slice-link" data-area="environment" href="products.html?area=environment">
-              <title>Physical Environment</title>
+              <title>Living Space</title>
               <path class="life-wheel__slice" fill="#14B8A6" d="M 180 180 L 20.0 180.0 A 160 160 0 0 1 66.863 66.863 Z"/>
             </a>
             <a class="life-wheel__slice-link" data-area="spirituality" href="products.html?area=spirituality">

--- a/style.css
+++ b/style.css
@@ -24,7 +24,7 @@ img{max-width:100%;display:block}
 .brand__logo{width:48px;height:48px;object-fit:contain;display:block;flex-shrink:0}
 .brand__text{display:flex;flex-direction:column;gap:2px;line-height:1.05}
 .brand__name{font-size:1.12rem;font-weight:700;color:inherit}
-.brand__notice{font-size:.75rem;font-weight:600;color:#dc2626;letter-spacing:.08em;text-transform:uppercase}
+.brand__notice{font-size:.75rem;font-weight:600;color:#111827;letter-spacing:.08em;text-transform:uppercase}
 .brand:hover,.brand:focus-visible{color:#1d4ed8}
 .main-nav{display:flex;align-items:center;gap:10px;padding:4.8px 8px;border-radius:999px;background:rgba(255,255,255,.78);border:1px solid rgba(148,163,184,.22);box-shadow:0 12px 30px rgba(15,23,42,.08);position:relative}
 .nav-item{position:relative}
@@ -206,9 +206,9 @@ body[class*="theme-midnight"]{
 .hero-heading__dynamic.is-flip .hero-letter__face{display:inline-block;line-height:1;padding:0 .01em;backface-visibility:hidden;transform-style:preserve-3d}
 .hero-heading__dynamic.is-flip .hero-letter__face--blank{color:transparent}
 .hero-heading__dynamic.is-flip .hero-letter__face--back{transform:rotateX(180deg)}
-.hero-heading__tagline{display:inline-flex;align-items:center;gap:.4ch;padding:clamp(.18rem,.7vw,.32rem) clamp(.48rem,1.4vw,.82rem);border-radius:999px;border:1px solid rgba(15,23,42,.12);background:linear-gradient(145deg,#f8fafc,#eef2f7);color:#1e293b;font-weight:700;text-transform:uppercase;letter-spacing:.12em;font-size:clamp(.52rem,.46rem + .8vw,.9rem);box-shadow:inset 0 2px 6px rgba(15,23,42,.12),inset 0 -1px 0 rgba(255,255,255,.85),0 8px 20px rgba(15,23,42,.05);white-space:nowrap;line-height:1.3}
+.hero-heading__tagline{display:inline-flex;align-items:center;gap:.4ch;padding:clamp(.18rem,.7vw,.32rem) clamp(.48rem,1.4vw,.82rem);border-radius:999px;border:1px solid rgba(15,23,42,.08);background:linear-gradient(145deg,#f8fafc,#f1f5f9);color:rgba(15,23,42,.72);font-weight:600;text-transform:uppercase;letter-spacing:.12em;font-size:clamp(.52rem,.46rem + .8vw,.9rem);box-shadow:inset 0 1px 4px rgba(15,23,42,.08),inset 0 -1px 0 rgba(255,255,255,.7),0 6px 14px rgba(15,23,42,.04);white-space:nowrap;line-height:1.3}
 .hero-heading__tagline::before{content:"-";font-size:1.05em;line-height:1;opacity:.7;transform:translateY(-.04em)}
-.hero-heading__tagline-em{color:#312e81;text-shadow:0 1px 2px rgba(15,23,42,.18)}
+.hero-heading__tagline-em{color:rgba(79,70,229,.7);text-shadow:none}
 .hero h1 .hero-heading__dynamic,.hero h1 .hero-heading__tagline{line-height:1.1}
 .hero-heading__dynamic::after{content:"";display:block;width:100%;height:2px;margin-top:6px;background:linear-gradient(90deg,currentColor 0%,rgba(37,99,235,0) 100%);opacity:.25}
 .hero-heading__dynamic.is-wave{opacity:1;transform:translateY(0)}


### PR DESCRIPTION
## Summary
- remove the one-time purchase blurb from the index header and mute the hero tagline styling
- rename the Environment category to Living Space across the homepage data so menus reflect the new wording

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d7eedc983c832d8c3c00488a4f704f