### PR TITLE
Refresh hero with rotating line art

### DIFF
--- a/app.js
+++ b/app.js
@@ -254,9 +254,27 @@ App.LIFE_AREAS = {
  * Hero headline rotation (index)
  *****************************************************/
 App.HERO_ROTATIONS = [
-  { text: "Create Harmony in Your Life", color: "#6366F1", animation: "glide" },
-  { text: "From Chaos to Clarity", color: "#14B8A6", animation: "wave" },
-  { text: "Bring Balance to Your Day", color: "#F97316", animation: "flip" }
+  {
+    text: "Create Harmony in Your Life",
+    color: "#6366F1",
+    animation: "glide",
+    illustration: "assets/hero-line-harmony.svg",
+    illustrationAlt: "Abstract concentric lines with sparkles representing harmony"
+  },
+  {
+    text: "From Chaos to Clarity",
+    color: "#14B8A6",
+    animation: "wave",
+    illustration: "assets/hero-line-clarity.svg",
+    illustrationAlt: "Flowing lines gathering into a focused beam"
+  },
+  {
+    text: "Bring Balance to Your Day",
+    color: "#F97316",
+    animation: "flip",
+    illustration: "assets/hero-line-balance.svg",
+    illustrationAlt: "Line art scales balancing sun and moon shapes"
+  }
 ];
 
 App.initHeroRotation = function() {
@@ -265,6 +283,10 @@ App.initHeroRotation = function() {
 
   target.dataset.heroRotationInit = "true";
   target.setAttribute("aria-live", "polite");
+
+  const illustration = App.qs("[data-hero-illustration]");
+  const defaultIllustrationSrc = illustration ? illustration.getAttribute("src") || "" : "";
+  const defaultIllustrationAlt = illustration ? illustration.getAttribute("alt") || "" : "";
 
   const phrases = Array.isArray(App.HERO_ROTATIONS)
     ? App.HERO_ROTATIONS.filter(item => item && item.text)
@@ -351,9 +373,29 @@ App.initHeroRotation = function() {
     target.appendChild(srText);
   };
 
+  const updateIllustration = phrase => {
+    if (!illustration) return;
+
+    if (phrase && phrase.illustration) {
+      const nextSrc = phrase.illustration;
+      if (illustration.getAttribute("src") !== nextSrc) {
+        illustration.setAttribute("src", nextSrc);
+      }
+    } else if (defaultIllustrationSrc) {
+      illustration.setAttribute("src", defaultIllustrationSrc);
+    }
+
+    if (phrase && Object.prototype.hasOwnProperty.call(phrase, "illustrationAlt")) {
+      illustration.setAttribute("alt", phrase.illustrationAlt || "");
+    } else {
+      illustration.setAttribute("alt", defaultIllustrationAlt);
+    }
+  };
+
   const applyPhrase = (phrase, previousPhrase) => {
     target.innerHTML = "";
     target.dataset.text = phrase.text;
+    updateIllustration(phrase);
 
     if (phrase.animation === "flip") {
       createFlipSpan(phrase.text, previousPhrase ? previousPhrase.text : "");

--- a/assets/hero-line-balance.svg
+++ b/assets/hero-line-balance.svg
@@ -1,0 +1,27 @@
+<svg width="320" height="200" viewBox="0 0 320 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g stroke="#F97316" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M60 164h200" opacity="0.6" />
+    <path d="M160 40v124" />
+    <path d="M92 124c0 18 14 32 32 32s32-14 32-32" opacity="0.8" />
+    <path d="M164 124c0 18 14 32 32 32s32-14 32-32" opacity="0.8" />
+    <path d="M124 84h72" opacity="0.6" />
+    <path d="M108 164v-12" opacity="0.6" />
+    <path d="M212 164v-12" opacity="0.6" />
+    <path d="M92 124h64" opacity="0.4" />
+    <path d="M164 124h64" opacity="0.4" />
+    <path d="M160 40c-10 8-18 22-18 36 0 18 10 34 18 42" opacity="0.5" />
+    <path d="M160 40c10 8 18 22 18 36 0 18-10 34-18 42" opacity="0.5" />
+  </g>
+  <g stroke="#FDBA74" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="124" cy="124" r="20" opacity="0.8" />
+    <circle cx="196" cy="124" r="20" opacity="0.5" />
+    <path d="M160 92l-20-20" opacity="0.7" />
+    <path d="M160 92l20-20" opacity="0.7" />
+    <path d="M160 60h-24" opacity="0.6" />
+    <path d="M160 60h24" opacity="0.6" />
+    <path d="M76 164c12-8 26-12 40-12" opacity="0.4" />
+    <path d="M244 164c-12-8-26-12-40-12" opacity="0.4" />
+    <path d="M60 176h200" opacity="0.4" />
+    <path d="M160 176c0 8-6 12-12 12h24c-6 0-12-4-12-12Z" opacity="0.5" />
+  </g>
+</svg>

--- a/assets/hero-line-clarity.svg
+++ b/assets/hero-line-clarity.svg
@@ -1,0 +1,27 @@
+<svg width="320" height="200" viewBox="0 0 320 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g stroke="#14B8A6" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M36 148c36-40 84-60 124-60s88 20 124 60" opacity="0.45" />
+    <path d="M60 144c28-28 68-42 100-42s72 14 100 42" opacity="0.45" />
+    <path d="M84 140c22-20 52-30 76-30s54 10 76 30" opacity="0.7" />
+    <path d="M108 136c16-12 36-18 52-18s36 6 52 18" opacity="0.9" />
+    <path d="M152 124c6-4 16-6 24-6s18 2 24 6" opacity="0.9" />
+    <path d="M36 72c24 6 44 20 60 38" opacity="0.45" />
+    <path d="M284 72c-24 6-44 20-60 38" opacity="0.45" />
+    <path d="M160 46c0 30-10 58-30 80" opacity="0.45" />
+    <path d="M160 46c0 30 10 58 30 80" opacity="0.45" />
+  </g>
+  <g stroke="#5EEAD4" stroke-width="2" stroke-linecap="round">
+    <path d="M160 30l-12 18" opacity="0.6" />
+    <path d="M160 30l12 18" opacity="0.6" />
+    <path d="M148 48h24" opacity="0.6" />
+    <path d="M132 174c20-22 40-42 60-60l58-52" opacity="0.7" />
+    <path d="M188 120l36 68" opacity="0.7" />
+    <path d="M124 120l-36 68" opacity="0.4" />
+    <path d="M80 96l12 12" opacity="0.4" />
+    <path d="M240 96l-12 12" opacity="0.4" />
+    <path d="M160 120l100 52" opacity="0.4" />
+    <path d="M160 120L60 172" opacity="0.4" />
+  </g>
+  <path d="M192 128l64 32-64 32-64-32 64-32Z" stroke="#14B8A6" stroke-width="3" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.75" />
+  <path d="M192 128l24 32-24 32-24-32 24-32Z" stroke="#5EEAD4" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" fill="none" opacity="0.9" />
+</svg>

--- a/assets/hero-line-harmony.svg
+++ b/assets/hero-line-harmony.svg
@@ -1,0 +1,29 @@
+<svg width="320" height="200" viewBox="0 0 320 200" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <g stroke="#6366F1" stroke-width="3" stroke-linecap="round" stroke-linejoin="round">
+    <circle cx="160" cy="100" r="68" opacity="0.9" />
+    <circle cx="160" cy="100" r="48" opacity="0.5" stroke-dasharray="12 14" />
+    <path d="M98 128c12 18 36 32 62 32s50-14 62-32" opacity="0.45" />
+    <path d="M160 36c-18 12-30 32-30 54s12 42 30 54" opacity="0.45" />
+    <path d="M160 36c18 12 30 32 30 54s-12 42-30 54" opacity="0.45" />
+    <path d="M70 70c10-8 26-16 44-18" opacity="0.35" />
+    <path d="M250 70c-10-8-26-16-44-18" opacity="0.35" />
+    <path d="M160 16v12" />
+    <path d="M160 172v12" />
+    <path d="M84 100h-12" opacity="0.6" />
+    <path d="M248 100h12" opacity="0.6" />
+    <path d="M108 44l-6-10" opacity="0.6" />
+    <path d="M212 44l6-10" opacity="0.6" />
+    <path d="M108 156l-6 10" opacity="0.6" />
+    <path d="M212 156l6 10" opacity="0.6" />
+  </g>
+  <g stroke="#A5B4FC" stroke-width="2" stroke-linecap="round">
+    <path d="M42 100c0-30 14-58 38-76" opacity="0.4" />
+    <path d="M278 100c0-30-14-58-38-76" opacity="0.4" />
+    <path d="M42 100c0 30 14 58 38 76" opacity="0.4" />
+    <path d="M278 100c0 30-14 58-38 76" opacity="0.4" />
+    <path d="M160 100l28-28" opacity="0.5" />
+    <path d="M160 100l-28-28" opacity="0.5" />
+    <path d="M160 100l28 28" opacity="0.5" />
+    <path d="M160 100l-28 28" opacity="0.5" />
+  </g>
+</svg>

--- a/index.html
+++ b/index.html
@@ -79,11 +79,9 @@
       <span class="hero-heading__dynamic" data-hero-rotate data-text="Create Harmony in Your Life">Create Harmony in Your Life</span>
       <span class="hero-heading__tagline" aria-label="- Powered by Next-Gen Google Sheets">Powered by Next-<span class="hero-heading__tagline-em">Gen</span> Google Sheets</span>
     </h1>
-    <p>Elegant, app-like interfaces on top of spreadsheet “databases.”</p>
-    <div class="hero-cta">
-      <a class="btn primary" href="products.html">Browse all products</a>
-      <a class="btn ghost" href="https://www.etsy.com/no-en/shop/HarmonySheets" target="_blank" rel="noopener">Buy on Etsy</a>
-    </div>
+    <figure class="hero-visual">
+      <img src="assets/hero-line-harmony.svg" alt="Abstract concentric lines with sparkles representing harmony" data-hero-illustration>
+    </figure>
   </section>
 
   <section id="life-wheel" class="life-wheel">

--- a/style.css
+++ b/style.css
@@ -240,12 +240,13 @@ body[class*="theme-midnight"]{
 .hero h1 .hero-heading__dynamic,.hero h1 .hero-heading__tagline{line-height:1.1}
 .hero-heading__dynamic::after{content:"";display:block;width:100%;height:2px;margin-top:6px;background:linear-gradient(90deg,currentColor 0%,rgba(37,99,235,0) 100%);opacity:.25}
 .hero-heading__dynamic.is-wave{opacity:1;transform:translateY(0)}
+.hero-visual{margin:clamp(24px,6vw,48px) auto 0;display:flex;justify-content:center}
+.hero-visual img{width:min(320px,80vw);height:auto;filter:drop-shadow(0 22px 36px rgba(15,23,42,.12));transition:opacity .3s ease}
 @keyframes heroGlide{0%{opacity:0;transform:translateY(24px)}32%{opacity:1;transform:translateY(0)}100%{opacity:1;transform:translateY(0)}}
 @keyframes heroLetterCalm{0%{opacity:0;transform:translateY(12px)}100%{opacity:1;transform:translateY(0)}}
 @keyframes heroLetterFlip{0%{transform:rotateX(0)}48%{transform:rotateX(88deg)}52%{transform:rotateX(92deg)}100%{transform:rotateX(180deg)}}
 @keyframes heroWaveGlow{0%{opacity:0;transform:translateX(-32%)}18%{opacity:1;transform:translateX(-12%)}45%{transform:translateX(8%);filter:drop-shadow(0 0 .6em rgba(96,165,250,.75))}70%{transform:translateX(24%);filter:drop-shadow(0 0 .45em rgba(96,165,250,.55))}100%{opacity:0;transform:translateX(46%);filter:drop-shadow(0 0 .25em rgba(96,165,250,.35))}}
 .hero p{color:var(--muted)}
-.hero-cta{margin-top:18px;display:flex;gap:10px;justify-content:center}
 .btn{display:inline-block;padding:11px 16px;border:1px solid var(--brand);border-radius:10px;box-shadow:var(--shadow)}
 .btn.primary{background:var(--brand);color:#fff}
 .btn.ghost{background:#eef3ff;color:var(--brand);border-color:#dbe6ff}


### PR DESCRIPTION
## Summary
- replace the hero tagline paragraph and CTA buttons with a rotating line-art illustration synced to the headline phrases
- add dedicated styling for the hero illustration and three new SVG assets for each headline state
- extend the hero rotation script to swap illustration sources and alt text alongside the phrase changes

## Testing
- `python3 -m http.server 8000`

------
https://chatgpt.com/codex/tasks/task_e_68d7f46955c0832d9902e4f417fc70ab