### PR TITLE
Remove sticky product purchase banner

### DIFF
--- a/app.js
+++ b/app.js
@@ -2649,7 +2649,6 @@ App.initProduct = async function() {
     document.title = product.name + " — Harmony Sheets";
     App.qs("#p-name").textContent = product.name;
     if (App.qs("#p-title")) App.qs("#p-title").textContent = product.name;
-    if (App.qs("#p-sticky-name")) App.qs("#p-sticky-name").textContent = product.name;
 
     // Tagline
     if (product.tagline) App.qs("#p-tagline").textContent = product.tagline;
@@ -2734,11 +2733,11 @@ App.initProduct = async function() {
     if (product.pricingSub && App.qs("#p-pricing-sub")) App.qs("#p-pricing-sub").textContent = product.pricingSub;
 
     // Links
-    ["p-stripe", "p-stripe-2", "p-stripe-sticky"].forEach(id => {
+    ["p-stripe", "p-stripe-2"].forEach(id => {
       const el = App.qs("#" + id);
       if (el && product.stripe) el.href = product.stripe;
     });
-    ["p-etsy", "p-etsy-2", "p-etsy-sticky"].forEach(id => {
+    ["p-etsy", "p-etsy-2"].forEach(id => {
       const el = App.qs("#" + id);
       if (el && product.etsy) el.href = product.etsy;
     });

--- a/product.html
+++ b/product.html
@@ -151,17 +151,6 @@
     </section>
   </main>
 
-  <div class="sticky-cta">
-    <div class="bar">
-      <span class="muted" id="p-sticky-name"></span>
-      <div class="actions actions--compact" style="margin:0">
-        <button id="p-add-cart-sticky" class="btn ghost" type="button" data-add-to-cart>Add to cart</button>
-        <a id="p-stripe-sticky" class="btn primary" target="_blank" rel="noopener">Buy now</a>
-      </div>
-      <a id="p-etsy-sticky" class="text-link" target="_blank" rel="noopener">Etsy</a>
-    </div>
-  </div>
-
   <footer class="site-footer">
     <div class="site-footer__inner">
       <div class="site-footer__grid">

--- a/style.css
+++ b/style.css
@@ -559,9 +559,6 @@ body.page-bundle main{max-width:1120px;margin:0 auto;padding:48px 18px 80px;disp
 details.faq{border:1px solid #eee;border-radius:10px;padding:12px;background:#fff}
 details.faq+details.faq{margin-top:10px}
 details.faq summary{cursor:pointer;font-weight:600}
-.sticky-cta{position:sticky;bottom:0;z-index:50;border-top:1px solid #eee;background:rgba(255,255,255,.85);backdrop-filter:saturate(180%) blur(8px)}
-.sticky-cta .bar{display:flex;gap:10px;align-items:center;justify-content:space-between;max-width:1080px;margin:0 auto;padding:.75rem 1rem}
-.sticky-cta .muted{color:#777;font-size:.9rem}
 
 /* === Support & policy pages === */
 .faq{max-width:900px;margin:0 auto;padding:clamp(32px,6vw,60px) clamp(20px,6vw,32px);display:grid;gap:32px}


### PR DESCRIPTION
## Summary
- remove the sticky purchase bar from product pages now that other calls to action remain
- clean up product page styling and scripts to align with the removed banner

## Testing
- not run (static site changes)

------
https://chatgpt.com/codex/tasks/task_e_68d80af0d86c832d930f43da0a5ee720