### PR TITLE
Stop auto-highlighting mega menu products until hover

### DIFF
--- a/app.js
+++ b/app.js
@@ -1612,13 +1612,17 @@ App.initNavDropdown = function() {
           })
           .join("");
         rowsEl.innerHTML = rows;
-        if (firstNavId && previewItemMap.has(firstNavId)) {
-          const firstItem = previewItemMap.get(firstNavId);
-          const firstRow = findRowById(firstNavId);
-          renderPreview(firstItem, firstRow || undefined, firstNavId);
-        } else {
-          previewDefault();
+
+        if (activePreviewId && previewItemMap.has(activePreviewId)) {
+          const activeItem = previewItemMap.get(activePreviewId);
+          const activeRow = findRowById(activePreviewId);
+          if (activeItem && activeRow) {
+            renderPreview(activeItem, activeRow, activePreviewId);
+            return;
+          }
         }
+
+        resetPreview();
       }
     }
 


### PR DESCRIPTION
## Summary
- prevent the navigation mega menu from auto-selecting the first product when a category changes
- keep any existing preview highlight if it is still available, otherwise show the default placeholder

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d81387dab8832db9990de66b346d11