### PR TITLE
Adjust All Products mega menu pill styling

### DIFF
--- a/style.css
+++ b/style.css
@@ -52,10 +52,10 @@ button.nav-link{border:0;background:transparent;cursor:pointer;font:inherit}
 .nav-mega__catbtn{width:100%;display:flex;align-items:center;gap:12px;border:1px solid transparent;background:transparent;color:var(--nav-mega-ink);padding:12px 14px;border-radius:12px;cursor:pointer;font:inherit;text-align:left;transition:background .2s ease,border-color .2s ease,transform .2s ease;font-size:.98rem}
 .nav-mega__catbtn:hover,.nav-mega__catbtn:focus-visible{background:#fff;border-color:var(--nav-mega-line);outline:none}
 .nav-mega__catbtn[aria-current="true"]{background:#fff;border-color:var(--nav-mega-line);box-shadow:0 0 0 1px rgba(148,163,184,.2)}
-.nav-mega__catbtn--all{background:linear-gradient(140deg,rgba(14,165,233,.14),rgba(14,165,233,.04));border-color:color-mix(in srgb,#0ea5e9 42%,rgba(148,163,184,.25));color:color-mix(in srgb,#0ea5e9 68%,var(--nav-mega-ink));box-shadow:inset 0 1px 0 rgba(255,255,255,.6),0 1px 3px rgba(14,165,233,.18)}
-.nav-mega__catbtn--all .nav-mega__count{color:color-mix(in srgb,#0ea5e9 68%,var(--nav-mega-muted))}
-.nav-mega__catbtn--all:hover,.nav-mega__catbtn--all:focus-visible{background:linear-gradient(140deg,rgba(14,165,233,.22),rgba(14,165,233,.08));border-color:color-mix(in srgb,#0ea5e9 58%,rgba(148,163,184,.25))}
-.nav-mega__catbtn--all[aria-current="true"]{background:linear-gradient(140deg,rgba(14,165,233,.32),rgba(14,165,233,.12));border-color:color-mix(in srgb,#0ea5e9 65%,rgba(148,163,184,.35));box-shadow:0 0 0 1px color-mix(in srgb,#0ea5e9 36%,transparent),0 6px 14px rgba(14,165,233,.18)}
+.nav-mega__catbtn--all{border-radius:999px;border-color:color-mix(in srgb,var(--nav-mega-line) 80%,transparent);background:transparent;color:var(--nav-mega-ink);box-shadow:none}
+.nav-mega__catbtn--all .nav-mega__count{color:var(--nav-mega-muted)}
+.nav-mega__catbtn--all:hover,.nav-mega__catbtn--all:focus-visible{border-color:var(--nav-mega-line);background:#fff}
+.nav-mega__catbtn--all[aria-current="true"]{background:#fff;border-color:color-mix(in srgb,var(--nav-mega-line) 90%,transparent);box-shadow:0 0 0 1px rgba(148,163,184,.24),0 6px 14px rgba(148,163,184,.18)}
 .nav-mega__dot{width:8px;height:8px;border-radius:50%;flex-shrink:0}
 .nav-mega__dot--all{background:#0ea5e9}
 .nav-mega__dot--love{background:#ef5da8}


### PR DESCRIPTION
## Summary
- restyle the "All Products" mega menu category button as a pill with neutral defaults
- align hover and active treatments with the neutral palette while keeping count legible

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8152dc270832db2e6ad85fd5276df