### PR TITLE
Simplify navigation mega preview

### DIFF
--- a/app.js
+++ b/app.js
@@ -1383,10 +1383,6 @@ App.initNavDropdown = function() {
     const safeName = App.escapeHtml(item.name || "Harmony Sheets tool");
     const safeTagline = App.escapeHtml(item.tagline || "");
     const safeUrl = App.escapeHtml(item.url || "#");
-    const badgeText = String(item.badge || "").trim();
-    const badgeMarkup = badgeText
-      ? `<span class="nav-mega__preview-badge">${App.escapeHtml(badgeText)}</span>`
-      : "";
     const fallbackAccent = navAccentMap[navState.cat] || getCategoryInfo(navState.cat)?.color || navAccentMap.all;
     const previewAccent = item.accentColor || fallbackAccent;
     previewEl.style.setProperty("--nav-mega-preview-acc", previewAccent);
@@ -1406,7 +1402,6 @@ App.initNavDropdown = function() {
 
     previewContentEl.innerHTML = `
       ${mediaMarkup}
-      ${badgeMarkup}
       <h3 class="nav-mega__preview-title">${safeName}</h3>
       ${safeTagline ? `<p class="nav-mega__preview-tagline">${safeTagline}</p>` : ""}
       ${factsMarkup ? `<ul class="nav-mega__preview-facts">${factsMarkup}</ul>` : ""}

--- a/style.css
+++ b/style.css
@@ -74,7 +74,7 @@ button.nav-link{border:0;background:transparent;cursor:pointer;font:inherit}
 .nav-mega__preview-content{position:relative;z-index:1;display:flex;flex-direction:column;gap:14px}
 .nav-mega__preview-media{position:relative;border-radius:16px;overflow:hidden;box-shadow:0 18px 36px rgba(15,23,42,.12);background:linear-gradient(135deg,color-mix(in srgb,var(--nav-mega-preview-acc) 18%,rgba(255,255,255,.92)),rgba(255,255,255,.96));border:1px solid color-mix(in srgb,var(--nav-mega-preview-acc) 24%,rgba(15,23,42,.08));aspect-ratio:4/3;display:flex}
 .nav-mega__preview-img{width:100%;height:100%;object-fit:cover;display:block}
-.nav-mega__preview-media--placeholder{flex:1;display:flex;align-items:center;justify-content:center;color:color-mix(in srgb,var(--nav-mega-preview-acc) 60%,#0f172a);font-weight:700;font-size:1.8rem;letter-spacing:.04em;background:linear-gradient(140deg,color-mix(in srgb,var(--nav-mega-preview-acc) 22%,rgba(255,255,255,.94)),rgba(248,250,252,.9))}
+.nav-mega__preview-media--placeholder{flex:1;display:flex;align-items:center;justify-content:center;color:#94a3b8;font-weight:700;font-size:1.8rem;letter-spacing:.04em;background:transparent;border:2px solid #e2e8f0}
 .nav-mega__preview-media--placeholder span{opacity:.88}
 .nav-mega__preview.is-empty{justify-content:center}
 .nav-mega__preview.is-empty .nav-mega__preview-placeholder{color:var(--nav-mega-muted);font-size:.9rem;text-align:left;line-height:1.5}


### PR DESCRIPTION
## Summary
- remove the extra badge from the navigation mega menu preview card
- neutralize the preview placeholder styling so it only shows a light gray border

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68d8180cc144832da37ae958256d88bc