### PR TITLE
Refine product menu preview into stacked image gallery

### DIFF
--- a/style.css
+++ b/style.css
@@ -71,12 +71,16 @@ button.nav-link{border:0;background:transparent;cursor:pointer;font:inherit}
 .nav-mega__prod{padding:16px 18px;display:flex;flex-direction:column;gap:12px}
 .nav-mega__preview{--nav-mega-preview-acc:var(--nav-mega-acc);padding:20px 22px;border-left:1px solid var(--nav-mega-line);background:linear-gradient(180deg,color-mix(in srgb,var(--nav-mega-soft) 92%,#fff) 0%,#fff 88%);display:flex;flex-direction:column;gap:16px;min-height:100%;position:relative}
 .nav-mega__preview::after{content:"";position:absolute;inset:12px 18px;border-radius:18px;background:linear-gradient(145deg,rgba(255,255,255,.82),rgba(241,245,249,.55));box-shadow:0 18px 36px rgba(15,23,42,.12);z-index:0;opacity:.96;pointer-events:none}
-.nav-mega__preview-content{position:relative;z-index:1;display:flex;flex-direction:column;gap:14px}
-.nav-mega__preview-media{position:relative;border-radius:16px;overflow:hidden;box-shadow:0 18px 36px rgba(15,23,42,.12);background:linear-gradient(135deg,color-mix(in srgb,var(--nav-mega-preview-acc) 18%,rgba(255,255,255,.92)),rgba(255,255,255,.96));border:1px solid color-mix(in srgb,var(--nav-mega-preview-acc) 24%,rgba(15,23,42,.08));aspect-ratio:4/3;display:flex}
-.nav-mega__preview-img{width:100%;height:100%;object-fit:cover;display:block}
-.nav-mega__preview-media--placeholder{flex:1;display:flex;align-items:center;justify-content:center;color:#94a3b8;font-weight:700;font-size:1.8rem;letter-spacing:.04em;background:transparent;border:2px solid #e2e8f0}
-.nav-mega__preview-media--placeholder span{opacity:.88}
-.nav-mega__preview.is-empty{justify-content:center}
+.nav-mega__preview-content{position:relative;z-index:1;display:flex;flex-direction:column;gap:16px;height:100%;flex:1}
+.nav-mega__preview-gallery{flex:1;display:flex;flex-direction:column;gap:12px;min-height:0}
+.nav-mega__preview-item{position:relative;display:flex;align-items:stretch;justify-content:center;border-radius:16px;overflow:hidden;box-shadow:0 18px 36px rgba(15,23,42,.12);background:linear-gradient(135deg,color-mix(in srgb,var(--nav-mega-preview-acc) 18%,rgba(255,255,255,.92)),rgba(255,255,255,.96));border:1px solid color-mix(in srgb,var(--nav-mega-preview-acc) 24%,rgba(15,23,42,.08));transition:transform .2s ease,box-shadow .2s ease;flex:1;min-height:0;width:100%}
+.nav-mega__preview-item:hover{transform:translateY(-2px);box-shadow:0 22px 42px rgba(15,23,42,.16)}
+.nav-mega__preview-item:focus-visible{outline:2px solid var(--nav-mega-preview-acc);outline-offset:3px}
+.nav-mega__preview-img{width:100%;height:100%;object-fit:cover;display:block;transition:transform .3s ease}
+.nav-mega__preview-item:hover .nav-mega__preview-img{transform:scale(1.02)}
+.nav-mega__preview-item--placeholder{color:#94a3b8;font-weight:700;font-size:1.6rem;letter-spacing:.08em;background:transparent;border:2px dashed rgba(148,163,184,.45);box-shadow:none}
+.nav-mega__preview-item--placeholder span{margin:auto;opacity:.88}
+.nav-mega__preview.is-empty{justify-content:center;align-items:center}
 .nav-mega__preview.is-empty .nav-mega__preview-placeholder{color:var(--nav-mega-muted);font-size:.9rem;text-align:left;line-height:1.5}
 .nav-mega__preview-placeholder{margin:0;font-size:.92rem;line-height:1.54;color:color-mix(in srgb,var(--nav-mega-ink) 62%,#475569)}
 .nav-mega__preview-badge{align-self:flex-start;display:inline-flex;align-items:center;gap:6px;padding:4px 12px;border-radius:999px;font-size:.65rem;font-weight:700;text-transform:uppercase;letter-spacing:.14em;background:color-mix(in srgb,var(--nav-mega-acc) 16%,rgba(255,255,255,.92));color:color-mix(in srgb,var(--nav-mega-acc) 70%,#0f172a);border:1px solid color-mix(in srgb,var(--nav-mega-acc) 36%,transparent);box-shadow:0 6px 16px rgba(15,23,42,.08)}


### PR DESCRIPTION
## Summary
- replace the mega menu preview details with a three-image gallery that links to the selected product
- supply preview image data for featured products and gracefully fall back to placeholders when needed
- restyle the preview panel to support the vertical gallery layout and update the hover message

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d81caa8dd4832d85114acdf2bfb613