### PR TITLE
Update header tagline copy and mobile layout

### DIFF
--- a/about.html
+++ b/about.html
@@ -13,7 +13,7 @@
     <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
     <span class="brand__text">
       <span class="brand__name">Harmony Sheets</span>
-      <span class="brand__notice">One-time purchase. No subscriptions. You own the tool.</span>
+      <span class="brand__notice">No subscriptions. You own the tool.</span>
     </span>
   </a>
   <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">

--- a/affiliate.html
+++ b/affiliate.html
@@ -13,7 +13,7 @@
     <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
     <span class="brand__text">
       <span class="brand__name">Harmony Sheets</span>
-      <span class="brand__notice">One-time purchase. No subscriptions. You own the tool.</span>
+      <span class="brand__notice">No subscriptions. You own the tool.</span>
     </span>
   </a>
   <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">

--- a/bundle-back-to-school.html
+++ b/bundle-back-to-school.html
@@ -13,7 +13,7 @@
     <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
     <span class="brand__text">
       <span class="brand__name">Harmony Sheets</span>
-      <span class="brand__notice">One-time purchase. No subscriptions. You own the tool.</span>
+      <span class="brand__notice">No subscriptions. You own the tool.</span>
     </span>
   </a>
   <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">

--- a/bundle-full-life-hack.html
+++ b/bundle-full-life-hack.html
@@ -13,7 +13,7 @@
     <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
     <span class="brand__text">
       <span class="brand__name">Harmony Sheets</span>
-      <span class="brand__notice">One-time purchase. No subscriptions. You own the tool.</span>
+      <span class="brand__notice">No subscriptions. You own the tool.</span>
     </span>
   </a>
   <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">

--- a/bundle-personal-finance.html
+++ b/bundle-personal-finance.html
@@ -13,7 +13,7 @@
     <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
     <span class="brand__text">
       <span class="brand__name">Harmony Sheets</span>
-      <span class="brand__notice">One-time purchase. No subscriptions. You own the tool.</span>
+      <span class="brand__notice">No subscriptions. You own the tool.</span>
     </span>
   </a>
   <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">

--- a/bundle-premium.html
+++ b/bundle-premium.html
@@ -13,7 +13,7 @@
     <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
     <span class="brand__text">
       <span class="brand__name">Harmony Sheets</span>
-      <span class="brand__notice">One-time purchase. No subscriptions. You own the tool.</span>
+      <span class="brand__notice">No subscriptions. You own the tool.</span>
     </span>
   </a>
   <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">

--- a/bundles.html
+++ b/bundles.html
@@ -13,7 +13,7 @@
     <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
     <span class="brand__text">
       <span class="brand__name">Harmony Sheets</span>
-      <span class="brand__notice">One-time purchase. No subscriptions. You own the tool.</span>
+      <span class="brand__notice">No subscriptions. You own the tool.</span>
     </span>
   </a>
   <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">

--- a/faq.html
+++ b/faq.html
@@ -13,7 +13,7 @@
     <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
     <span class="brand__text">
       <span class="brand__name">Harmony Sheets</span>
-      <span class="brand__notice">One-time purchase. No subscriptions. You own the tool.</span>
+      <span class="brand__notice">No subscriptions. You own the tool.</span>
     </span>
   </a>
   <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">

--- a/policies.html
+++ b/policies.html
@@ -13,7 +13,7 @@
     <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
     <span class="brand__text">
       <span class="brand__name">Harmony Sheets</span>
-      <span class="brand__notice">One-time purchase. No subscriptions. You own the tool.</span>
+      <span class="brand__notice">No subscriptions. You own the tool.</span>
     </span>
   </a>
   <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">

--- a/product.html
+++ b/product.html
@@ -14,7 +14,7 @@
       <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
       <span class="brand__text">
         <span class="brand__name">Harmony Sheets</span>
-        <span class="brand__notice">One-time purchase. No subscriptions. You own the tool.</span>
+        <span class="brand__notice">No subscriptions. You own the tool.</span>
       </span>
     </a>
     <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">

--- a/products.html
+++ b/products.html
@@ -13,7 +13,7 @@
       <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
       <span class="brand__text">
         <span class="brand__name">Harmony Sheets</span>
-        <span class="brand__notice">One-time purchase. No subscriptions. You own the tool.</span>
+        <span class="brand__notice">No subscriptions. You own the tool.</span>
       </span>
     </a>
     <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">

--- a/style.css
+++ b/style.css
@@ -25,6 +25,12 @@ img{max-width:100%;display:block}
 .brand__text{display:flex;flex-direction:column;gap:2px;line-height:1.05}
 .brand__name{font-size:1.12rem;font-weight:700;color:inherit}
 .brand__notice{font-size:.75rem;font-weight:600;color:#111827;letter-spacing:.08em;text-transform:uppercase}
+
+@media (max-width:640px){
+  .brand{gap:6px}
+  .brand__text{gap:0}
+  .brand__notice{display:none}
+}
 .brand:hover,.brand:focus-visible{color:#1d4ed8}
 .main-nav{display:flex;align-items:center;gap:10px;padding:4.8px 8px;border-radius:999px;background:rgba(255,255,255,.78);border:1px solid rgba(148,163,184,.22);box-shadow:0 12px 30px rgba(15,23,42,.08);position:relative}
 .nav-item{position:relative}


### PR DESCRIPTION
## Summary
- align the header tagline across the interior pages with the shorter index copy
- hide the tagline on small screens so the mobile header shows only the brand name and logo

## Testing
- no automated tests were run

------
https://chatgpt.com/codex/tasks/task_e_68d8221343d0832d8362d2584970eace