### PR TITLE
Smooth hero illustration transitions

### DIFF
--- a/app.js
+++ b/app.js
@@ -260,15 +260,15 @@ App.HERO_ROTATIONS = [
     text: "Create Harmony in Your Life",
     color: "#6366F1",
     animation: "glide",
-    illustration: "assets/hero-line-harmony.svg",
-    illustrationAlt: "Abstract concentric lines with sparkles representing harmony"
+    illustration: "assets/imgIndex1.webp",
+    illustrationAlt: "Preview of Harmony Sheets templates displayed on multiple devices"
   },
   {
     text: "From Chaos to Clarity",
     color: "#14B8A6",
     animation: "wave",
-    illustration: "assets/hero-line-clarity.svg",
-    illustrationAlt: "Flowing lines gathering into a focused beam"
+    illustration: "assets/imgIndex2.webp",
+    illustrationAlt: "Close-up of Harmony Sheets dashboards highlighting clarity tools"
   },
   {
     text: "Bring Balance to Your Day",
@@ -419,20 +419,49 @@ App.initHeroRotation = function() {
   const updateIllustration = phrase => {
     if (!illustration) return;
 
-    if (phrase && phrase.illustration) {
-      const nextSrc = phrase.illustration;
-      if (illustration.getAttribute("src") !== nextSrc) {
-        illustration.setAttribute("src", nextSrc);
+    const nextSrc =
+      phrase && phrase.illustration ? phrase.illustration : defaultIllustrationSrc;
+    const hasCustomAlt =
+      phrase && Object.prototype.hasOwnProperty.call(phrase, "illustrationAlt");
+    const nextAlt = hasCustomAlt ? phrase.illustrationAlt || "" : defaultIllustrationAlt;
+
+    const setAltIfNeeded = () => {
+      if (illustration.getAttribute("alt") !== nextAlt) {
+        illustration.setAttribute("alt", nextAlt);
       }
-    } else if (defaultIllustrationSrc) {
-      illustration.setAttribute("src", defaultIllustrationSrc);
+    };
+
+    if (!nextSrc || illustration.getAttribute("src") === nextSrc) {
+      setAltIfNeeded();
+      return;
     }
 
-    if (phrase && Object.prototype.hasOwnProperty.call(phrase, "illustrationAlt")) {
-      illustration.setAttribute("alt", phrase.illustrationAlt || "");
-    } else {
-      illustration.setAttribute("alt", defaultIllustrationAlt);
-    }
+    const handleLoad = () => {
+      illustration.removeEventListener("load", handleLoad);
+      setAltIfNeeded();
+      window.requestAnimationFrame(() => {
+        illustration.classList.remove("is-fading");
+      });
+    };
+
+    const handleTransitionEnd = event => {
+      if (event.target !== illustration || event.propertyName !== "opacity") {
+        return;
+      }
+
+      illustration.removeEventListener("transitionend", handleTransitionEnd);
+      illustration.addEventListener("load", handleLoad);
+      illustration.setAttribute("src", nextSrc);
+
+      if (illustration.complete && illustration.naturalWidth !== 0) {
+        handleLoad();
+      }
+    };
+
+    illustration.addEventListener("transitionend", handleTransitionEnd);
+    window.requestAnimationFrame(() => {
+      illustration.classList.add("is-fading");
+    });
   };
 
   const applyPhrase = (phrase, previousPhrase) => {

--- a/index.html
+++ b/index.html
@@ -80,7 +80,7 @@
       <span class="hero-heading__tagline" aria-label="- Powered by Next-Gen Google Sheets">Powered by Next-<span class="hero-heading__tagline-em">Gen</span> Google Sheets</span>
     </h1>
     <figure class="hero-visual">
-      <img src="assets/hero-line-harmony.svg" alt="Abstract concentric lines with sparkles representing harmony" data-hero-illustration>
+      <img src="assets/imgIndex1.webp" alt="Preview of Harmony Sheets templates displayed on multiple devices" data-hero-illustration>
     </figure>
   </section>
 

--- a/style.css
+++ b/style.css
@@ -255,7 +255,8 @@ body[class*="theme-midnight"]{
 .hero-heading__dynamic::after{content:"";display:block;width:100%;height:2px;margin-top:6px;background:linear-gradient(90deg,currentColor 0%,rgba(37,99,235,0) 100%);opacity:.25}
 .hero-heading__dynamic.is-wave{opacity:1;transform:translateY(0)}
 .hero-visual{margin:clamp(24px,6vw,48px) auto 0;display:flex;justify-content:center}
-.hero-visual img{width:min(320px,80vw);height:auto;filter:drop-shadow(0 22px 36px rgba(15,23,42,.12));transition:opacity .3s ease}
+.hero-visual img{width:min(130px,35vw);height:auto;filter:drop-shadow(0 22px 36px rgba(15,23,42,.12));transition:opacity .6s ease;opacity:1}
+.hero-visual img.is-fading{opacity:0}
 @keyframes heroGlide{0%{opacity:0;transform:translateY(24px)}32%{opacity:1;transform:translateY(0)}100%{opacity:1;transform:translateY(0)}}
 @keyframes heroLetterCalm{0%{opacity:0;transform:translateY(12px)}100%{opacity:1;transform:translateY(0)}}
 @keyframes heroLetterFlip{0%{transform:rotateX(0)}48%{transform:rotateX(88deg)}52%{transform:rotateX(92deg)}100%{transform:rotateX(180deg)}}


### PR DESCRIPTION
## Summary
- shrink the homepage hero illustration by half for a lighter visual footprint
- add a fade transition when rotating hero imagery to avoid abrupt swaps

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d82c2dc4ec832dbd7224e84d256d40