### PR TITLE
Add Supabase-powered customer authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
 # harmony-sheets
 Website for Harmony Sheets — smart spreadsheet tools for organization, productivity, and planning.
+
+## Supabase authentication setup
+
+The customer login and freemium sign-up experience lives at [`login.html`](login.html) and is powered by Supabase Auth.
+
+1. Create a Supabase project (or reuse an existing one) and enable email/password authentication.
+2. Copy [`supabase-config.example.js`](supabase-config.example.js) to `supabase-config.js` (this repository already contains a placeholder file) and update the `SUPABASE_URL` and `SUPABASE_ANON_KEY` exports with your project's values.
+3. Optionally customize the `auth.users` email confirmation settings within Supabase. The sign-up flow automatically stores a `plan: "freemium"` attribute in the user's metadata.
+4. For password recovery emails, set the redirect URL in Supabase to `https://<your-domain>/login.html`. The page automatically handles the recovery token and allows the visitor to set a new password.
+
+> **Note:** Because Supabase's anon key is intended to be public, committing it to the static front-end is safe. Never expose service role keys in front-end code.

--- a/app.js
+++ b/app.js
@@ -1007,6 +1007,7 @@ App.initCart = function() {
  *****************************************************/
 App.init = function() {
   App.initNav();
+  App.initAuthLink();
   App.initCart();
 
   // Update footer year
@@ -1067,6 +1068,28 @@ App.init = function() {
 App.closeBrowseMenu = null;
 App.closeBundlesMenu = null;
 App.closeNavMenu = () => {};
+App.initAuthLink = function() {
+  const nav = App.qs(".main-nav");
+  if (!nav || nav.querySelector("[data-auth-link]")) return;
+
+  const authLink = document.createElement("a");
+  authLink.className = "nav-link nav-link--account";
+  authLink.href = "login.html";
+  authLink.textContent = "Account Login";
+  authLink.setAttribute("data-auth-link", "true");
+
+  if (App.qs("body.page-auth")) {
+    authLink.href = "products.html";
+    authLink.textContent = "Browse templates";
+  }
+
+  const cartToggle = nav.querySelector("[data-cart-toggle]");
+  if (cartToggle) {
+    nav.insertBefore(authLink, cartToggle);
+  } else {
+    nav.appendChild(authLink);
+  }
+};
 App.initNav = function() {
   const toggle = App.qs(".nav-toggle");
   const nav = App.qs(".main-nav");

--- a/auth.js
+++ b/auth.js
@@ -1,0 +1,331 @@
+import { createClient } from "https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2.42.7/+esm";
+import { SUPABASE_URL, SUPABASE_ANON_KEY, isSupabaseConfigured } from "./supabase-config.js";
+
+const statusEl = document.querySelector("[data-auth-status]");
+const forms = Array.from(document.querySelectorAll("[data-auth-form]"));
+const tabs = Array.from(document.querySelectorAll("[data-auth-tab]"));
+const redirect = new URLSearchParams(window.location.search).get("redirect") || "products.html";
+
+const resetForm = document.querySelector("[data-auth-form='reset']");
+const resetEmailField = resetForm?.querySelector("[data-reset-field='email']");
+const resetPasswordField = resetForm?.querySelector("[data-reset-field='new-password']");
+const resetConfirmField = resetForm?.querySelector("[data-reset-field='confirm-password']");
+const resetRequestHint = resetForm?.querySelector("[data-reset-hint='request']");
+const resetUpdateHint = resetForm?.querySelector("[data-reset-hint='update']");
+const resetSubmitButton = resetForm?.querySelector("button[type='submit']");
+
+let resetMode = "request";
+let supabaseClient = null;
+
+function setStatus(type, message) {
+  if (!statusEl) return;
+  statusEl.dataset.state = type;
+  statusEl.textContent = message;
+}
+
+function clearStatus() {
+  if (!statusEl) return;
+  statusEl.dataset.state = "";
+  statusEl.textContent = "";
+}
+
+function setLoading(form, isLoading) {
+  const submitButton = form.querySelector("button[type='submit']");
+  if (submitButton) {
+    submitButton.disabled = isLoading;
+    submitButton.dataset.loading = isLoading ? "true" : "false";
+  }
+  form.querySelectorAll("input, button").forEach((element) => {
+    if (element !== submitButton) {
+      element.disabled = isLoading;
+    }
+  });
+}
+
+function disableAllForms(message) {
+  forms.forEach((form) => {
+    form.querySelectorAll("input, button").forEach((element) => {
+      element.disabled = true;
+    });
+  });
+  tabs.forEach((tab) => {
+    tab.disabled = true;
+    tab.setAttribute("aria-disabled", "true");
+  });
+  setStatus("error", message);
+}
+
+function toggleTab(target) {
+  forms.forEach((form) => {
+    const isActive = form.dataset.authForm === target;
+    form.hidden = !isActive;
+    form.setAttribute("aria-hidden", (!isActive).toString());
+    if (isActive) {
+      const focusableInput = Array.from(form.querySelectorAll("input")).find(
+        (input) => input.offsetParent !== null && !input.disabled && input.type !== "hidden"
+      );
+      if (focusableInput) focusableInput.focus();
+    }
+  });
+
+  tabs.forEach((tab) => {
+    const isSelected = tab.dataset.authTab === target;
+    tab.setAttribute("aria-selected", isSelected.toString());
+    tab.classList.toggle("is-active", isSelected);
+  });
+}
+
+function configureResetForm(mode) {
+  resetMode = mode;
+  if (!resetForm) return;
+  const isUpdate = mode === "update";
+
+  if (resetEmailField) {
+    resetEmailField.hidden = isUpdate;
+    const emailInput = resetEmailField.querySelector("input");
+    if (emailInput) {
+      emailInput.required = !isUpdate;
+      if (isUpdate) {
+        emailInput.value = "";
+      } else {
+        emailInput.value = emailInput.value.trim();
+      }
+    }
+  }
+
+  if (resetPasswordField) {
+    resetPasswordField.hidden = !isUpdate;
+    const passwordInput = resetPasswordField.querySelector("input");
+    if (passwordInput) passwordInput.required = isUpdate;
+  }
+
+  if (resetConfirmField) {
+    resetConfirmField.hidden = !isUpdate;
+    const confirmInput = resetConfirmField.querySelector("input");
+    if (confirmInput) confirmInput.required = isUpdate;
+  }
+
+  if (resetRequestHint) resetRequestHint.hidden = isUpdate;
+  if (resetUpdateHint) resetUpdateHint.hidden = !isUpdate;
+
+  if (resetSubmitButton) {
+    resetSubmitButton.textContent = isUpdate ? "Update password" : "Send reset link";
+  }
+
+  if (isUpdate) {
+    const passwordInput = resetPasswordField?.querySelector("input");
+    if (passwordInput) passwordInput.focus();
+  }
+}
+
+function readAuthTabFromUrl() {
+  const params = new URLSearchParams(window.location.search);
+  const mode = params.get("mode") || params.get("tab");
+  if (mode && ["login", "signup", "reset"].includes(mode)) {
+    return mode;
+  }
+  return "login";
+}
+
+function initTabs() {
+  const initialTab = readAuthTabFromUrl();
+  toggleTab(initialTab);
+
+  tabs.forEach((tab) => {
+    tab.addEventListener("click", () => {
+      const target = tab.dataset.authTab;
+      toggleTab(target);
+      const params = new URLSearchParams(window.location.search);
+      params.set("mode", target);
+      const newUrl = `${window.location.pathname}?${params.toString()}${window.location.hash}`;
+      window.history.replaceState({}, "", newUrl);
+    });
+  });
+}
+
+function removeHashFromUrl() {
+  if (window.location.hash) {
+    const cleanUrl = window.location.pathname + window.location.search;
+    window.history.replaceState({}, "", cleanUrl);
+  }
+}
+
+async function handleLogin(event) {
+  event.preventDefault();
+  clearStatus();
+  const form = event.currentTarget;
+  const formData = new FormData(form);
+  const email = String(formData.get("email") || "").trim();
+  const password = String(formData.get("password") || "").trim();
+
+  if (!email || !password) {
+    setStatus("error", "Please enter your email and password.");
+    return;
+  }
+
+  setLoading(form, true);
+  const { error } = await supabaseClient.auth.signInWithPassword({ email, password });
+  setLoading(form, false);
+
+  if (error) {
+    setStatus("error", error.message);
+    return;
+  }
+
+  setStatus("success", "Welcome back! Redirecting to your dashboard…");
+  setTimeout(() => {
+    window.location.href = redirect;
+  }, 1200);
+}
+
+async function handleSignup(event) {
+  event.preventDefault();
+  clearStatus();
+  const form = event.currentTarget;
+  const formData = new FormData(form);
+  const email = String(formData.get("email") || "").trim();
+  const password = String(formData.get("password") || "").trim();
+
+  if (!email || !password) {
+    setStatus("error", "Enter an email and password to create your freemium account.");
+    return;
+  }
+
+  if (password.length < 8) {
+    setStatus("error", "Passwords must be at least 8 characters long.");
+    return;
+  }
+
+  setLoading(form, true);
+  const { data, error } = await supabaseClient.auth.signUp({
+    email,
+    password,
+    options: {
+      data: { plan: "freemium" },
+      emailRedirectTo: `${window.location.origin}/login.html?mode=login`,
+    },
+  });
+  setLoading(form, false);
+
+  if (error) {
+    setStatus("error", error.message);
+    return;
+  }
+
+  if (data.session) {
+    setStatus("success", "Freemium account created! Redirecting…");
+    setTimeout(() => {
+      window.location.href = redirect;
+    }, 1200);
+  } else {
+    setStatus(
+      "success",
+      "Check your email to confirm your account. You'll be able to sign in once it's verified."
+    );
+  }
+}
+
+async function handleReset(event) {
+  event.preventDefault();
+  clearStatus();
+  const form = event.currentTarget;
+
+  if (resetMode === "request") {
+    const emailInput = resetEmailField?.querySelector("input");
+    const email = String(emailInput?.value || "").trim();
+    if (!email) {
+      setStatus("error", "Enter the email you used for your account.");
+      return;
+    }
+
+    setLoading(form, true);
+    const { error } = await supabaseClient.auth.resetPasswordForEmail(email, {
+      redirectTo: `${window.location.origin}/login.html?mode=reset`,
+    });
+    setLoading(form, false);
+
+    if (error) {
+      setStatus("error", error.message);
+      return;
+    }
+
+    setStatus("success", "Password reset email sent! Check your inbox for the next steps.");
+    form.reset();
+  } else {
+    const passwordInput = resetPasswordField?.querySelector("input");
+    const confirmInput = resetConfirmField?.querySelector("input");
+    const password = String(passwordInput?.value || "").trim();
+    const confirm = String(confirmInput?.value || "").trim();
+
+    if (!password || !confirm) {
+      setStatus("error", "Enter and confirm your new password.");
+      return;
+    }
+
+    if (password !== confirm) {
+      setStatus("error", "Passwords do not match. Try again.");
+      return;
+    }
+
+    setLoading(form, true);
+    const { error } = await supabaseClient.auth.updateUser({ password });
+    setLoading(form, false);
+
+    if (error) {
+      setStatus("error", error.message);
+      return;
+    }
+
+    setStatus("success", "Password updated! You can now sign in with your new credentials.");
+    configureResetForm("request");
+    form.reset();
+    toggleTab("login");
+    removeHashFromUrl();
+  }
+}
+
+function bindFormHandlers() {
+  const loginForm = document.querySelector("[data-auth-form='login']");
+  const signupForm = document.querySelector("[data-auth-form='signup']");
+
+  loginForm?.addEventListener("submit", handleLogin);
+  signupForm?.addEventListener("submit", handleSignup);
+  resetForm?.addEventListener("submit", handleReset);
+}
+
+function detectRecoveryFlow() {
+  const hash = window.location.hash.replace("#", "");
+  const params = new URLSearchParams(hash);
+  const type = params.get("type");
+
+  if (type === "recovery") {
+    configureResetForm("update");
+    toggleTab("reset");
+    setStatus("info", "Enter a new password to finish resetting your account.");
+    removeHashFromUrl();
+  }
+}
+
+function init() {
+  if (!forms.length || !tabs.length) return;
+
+  initTabs();
+
+  if (!isSupabaseConfigured()) {
+    disableAllForms("Supabase credentials are missing. Update supabase-config.js to enable account access.");
+    return;
+  }
+
+  supabaseClient = createClient(SUPABASE_URL, SUPABASE_ANON_KEY, {
+    auth: {
+      persistSession: true,
+      detectSessionInUrl: true,
+    },
+  });
+
+  configureResetForm("request");
+  detectRecoveryFlow();
+  bindFormHandlers();
+}
+
+document.addEventListener("DOMContentLoaded", init);

--- a/login.html
+++ b/login.html
@@ -1,0 +1,221 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Account Access — Harmony Sheets</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="Sign in to your Harmony Sheets account or create a free freemium account powered by Supabase authentication.">
+  <link rel="icon" href="assets/favicon.svg" type="image/svg+xml">
+  <link rel="stylesheet" href="style.css">
+</head>
+<body class="theme-neutral page-auth">
+<header class="site-header">
+  <a class="brand" href="/">
+    <img class="brand__logo" src="assets/logoHarmonySheets.webp" alt="">
+    <span class="brand__text">
+      <span class="brand__name">Harmony Sheets</span>
+      <span class="brand__notice">Plan Better. Live Smarter.</span>
+    </span>
+  </a>
+  <button class="nav-toggle" type="button" aria-expanded="false" aria-controls="site-menu">
+    <span class="sr-only">Toggle navigation</span>
+    <span class="nav-toggle__icon" aria-hidden="true"></span>
+  </button>
+  <nav class="main-nav" id="site-menu">
+    <div class="nav-item nav-item--browse">
+      <a class="nav-link nav-link--browse" href="products.html" aria-haspopup="true" aria-expanded="false">Discover Life Harmony Apps/Templates</a>
+      <div class="nav-mega" role="menu" aria-label="Life Harmony categories">
+        <div class="nav-mega__content" data-nav-mega-content>
+          <p class="nav-mega__placeholder">Loading Life Harmony areas…</p>
+        </div>
+      </div>
+    </div>
+    <div class="nav-item nav-item--bundles">
+      <a class="nav-link nav-link--bundles" href="bundles.html" aria-haspopup="true" aria-expanded="false">Bundles</a>
+      <div class="nav-flyout" role="menu" aria-label="Featured bundles">
+        <div class="nav-flyout__content" data-nav-bundles>
+          <p class="nav-flyout__placeholder">Loading bundles…</p>
+        </div>
+      </div>
+    </div>
+    <a class="nav-link" href="faq.html">FAQ / Support</a>
+    <a class="nav-link" href="about.html">About</a>
+    <button class="nav-link nav-link--icon" type="button" data-cart-toggle aria-expanded="false" aria-controls="cart-panel">
+      <span class="sr-only" data-cart-label>View cart</span>
+      <svg class="nav-link__icon" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+        <g fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M3.5 4h2.6l1.6 9.2a1 1 0 0 0 1 .8h8.9a1 1 0 0 0 .97-.76L20 7.5H7.1"/>
+          <circle cx="10" cy="18.5" r="1.25"/>
+          <circle cx="17" cy="18.5" r="1.25"/>
+        </g>
+      </svg>
+      <span class="cart-count" data-cart-count>0</span>
+    </button>
+  </nav>
+</header>
+
+<div class="cart-overlay" data-cart-overlay></div>
+<aside class="cart-panel" id="cart-panel" aria-hidden="true" aria-labelledby="cart-panel-title" role="dialog" aria-modal="true">
+  <div class="cart-panel__header">
+    <h2 id="cart-panel-title">Your cart</h2>
+    <button class="cart-panel__close" type="button" data-cart-close aria-label="Close cart">
+      <span aria-hidden="true">×</span>
+    </button>
+  </div>
+  <div class="cart-panel__body" data-cart-items></div>
+  <div class="cart-panel__footer">
+    <div class="cart-panel__total">
+      <span>Total</span>
+      <strong data-cart-total>$0.00</strong>
+    </div>
+    <button class="btn primary cart-panel__checkout" type="button" data-cart-checkout>Checkout</button>
+    <p class="cart-panel__hint muted">Checkout grants instant access to your Harmony Sheets downloads.</p>
+  </div>
+</aside>
+
+<main class="auth-page" id="main-content">
+  <section class="auth">
+    <div class="auth-card">
+      <div class="auth-card__intro">
+        <h1>Access your Harmony Sheets account</h1>
+        <p>Sign in to manage your purchases or create a complimentary freemium account to explore Harmony Sheets before you upgrade.</p>
+      </div>
+      <div class="auth-tabs" role="tablist">
+        <button id="auth-tab-login" class="auth-tab" type="button" data-auth-tab="login" role="tab" aria-selected="true" aria-controls="auth-login-form">Sign in</button>
+        <button id="auth-tab-signup" class="auth-tab" type="button" data-auth-tab="signup" role="tab" aria-selected="false" aria-controls="auth-signup-form">Create freemium account</button>
+        <button id="auth-tab-reset" class="auth-tab auth-tab--ghost" type="button" data-auth-tab="reset" role="tab" aria-selected="false" aria-controls="auth-reset-form">Reset password</button>
+      </div>
+      <div class="auth-forms">
+        <form class="auth-form" id="auth-login-form" data-auth-form="login" role="tabpanel" aria-labelledby="auth-tab-login">
+          <div class="form-field">
+            <label for="login-email">Email address</label>
+            <input id="login-email" name="email" type="email" autocomplete="email" required>
+          </div>
+          <div class="form-field">
+            <label for="login-password">Password</label>
+            <input id="login-password" name="password" type="password" autocomplete="current-password" minlength="6" required>
+          </div>
+          <button class="btn primary auth-submit" type="submit">Sign in</button>
+        </form>
+        <form class="auth-form" id="auth-signup-form" data-auth-form="signup" role="tabpanel" aria-labelledby="auth-tab-signup" hidden>
+          <div class="form-field">
+            <label for="signup-email">Email address</label>
+            <input id="signup-email" name="email" type="email" autocomplete="email" required>
+          </div>
+          <div class="form-field">
+            <label for="signup-password">Password</label>
+            <input id="signup-password" name="password" type="password" autocomplete="new-password" minlength="8" required>
+            <p class="form-hint">Minimum 8 characters. You'll receive freemium access instantly.</p>
+          </div>
+          <button class="btn primary auth-submit" type="submit">Create freemium account</button>
+        </form>
+        <form class="auth-form" id="auth-reset-form" data-auth-form="reset" role="tabpanel" aria-labelledby="auth-tab-reset" hidden>
+          <div class="form-field" data-reset-field="email">
+            <label for="reset-email">Email address</label>
+            <input id="reset-email" name="email" type="email" autocomplete="email">
+            <p class="form-hint" data-reset-hint="request">We'll email you a link to set a new password.</p>
+          </div>
+          <div class="form-field" data-reset-field="new-password" hidden>
+            <label for="reset-password">New password</label>
+            <input id="reset-password" name="password" type="password" autocomplete="new-password" minlength="8">
+          </div>
+          <div class="form-field" data-reset-field="confirm-password" hidden>
+            <label for="reset-password-confirm">Confirm new password</label>
+            <input id="reset-password-confirm" name="confirm" type="password" autocomplete="new-password" minlength="8">
+            <p class="form-hint" data-reset-hint="update" hidden>Enter your new password to finish resetting your account.</p>
+          </div>
+          <button class="btn primary auth-submit" type="submit">Send reset link</button>
+        </form>
+      </div>
+      <p class="auth-status" data-auth-status role="status" aria-live="polite"></p>
+      <aside class="auth-benefits" aria-label="Freemium account benefits">
+        <h2>What's included in freemium?</h2>
+        <ul>
+          <li>Access to rotating sample templates from the Life Harmony library.</li>
+          <li>Personalized product recommendations based on your interests.</li>
+          <li>Saved cart and order history when you upgrade to any premium template.</li>
+        </ul>
+        <p class="auth-benefits__note">Freemium accounts are powered by secure Supabase authentication.</p>
+      </aside>
+    </div>
+  </section>
+</main>
+
+<footer class="site-footer">
+  <div class="site-footer__inner">
+    <div class="site-footer__grid">
+      <div class="site-footer__column">
+        <h3 class="site-footer__heading">Customer Support</h3>
+        <ul class="site-footer__links">
+          <li><a href="faq.html#guides">Information Guides</a></li>
+          <li><a href="faq.html">FAQ / Support</a></li>
+          <li><a href="faq.html#contact">Contact Us</a></li>
+        </ul>
+      </div>
+      <div class="site-footer__column">
+        <h3 class="site-footer__heading">Policies</h3>
+        <ul class="site-footer__links">
+          <li><a href="policies.html#privacy">Privacy Policy</a></li>
+          <li><a href="policies.html#delivery">Delivery Policy</a></li>
+          <li><a href="policies.html#refund">Refund Policy</a></li>
+          <li><a href="policies.html#terms">Terms of Service</a></li>
+        </ul>
+      </div>
+      <div class="site-footer__column">
+        <h3 class="site-footer__heading">Affiliate</h3>
+        <ul class="site-footer__links">
+          <li><a href="affiliate.html#apply">Become an Affiliate</a></li>
+          <li><a href="affiliate.html#login">Affiliate Login</a></li>
+        </ul>
+      </div>
+      <div class="site-footer__column site-footer__column--newsletter">
+        <h3 class="site-footer__heading">Social &amp; Newsletter</h3>
+        <form id="footer-newsletter" class="footer-form">
+          <label class="sr-only" for="footer-email">Email address</label>
+          <div class="footer-form__controls">
+            <input id="footer-email" type="email" name="email" placeholder="Enter email" required>
+            <button type="submit" class="footer-form__submit">Join</button>
+          </div>
+        </form>
+        <p class="site-footer__note">Subscribe to receive exclusive releases, deals, and event updates.</p>
+        <div class="site-footer__social">
+          <a class="site-footer__social-link" href="https://www.instagram.com/harmonysheets" target="_blank" rel="noopener" aria-label="Instagram">
+            <span aria-hidden="true">IG</span>
+          </a>
+          <a class="site-footer__social-link" href="https://www.youtube.com/@HarmonySheets" target="_blank" rel="noopener" aria-label="YouTube">
+            <span aria-hidden="true">YT</span>
+          </a>
+          <a class="site-footer__social-link" href="https://www.pinterest.com/harmonysheets" target="_blank" rel="noopener" aria-label="Pinterest">
+            <span aria-hidden="true">PI</span>
+          </a>
+          <a class="site-footer__social-link" href="mailto:support@harmony-sheets.com" aria-label="Email Harmony Sheets">
+            <span aria-hidden="true">@</span>
+          </a>
+        </div>
+        <p id="footer-newsletter-status" class="site-footer__status" role="status" aria-live="polite"></p>
+      </div>
+    </div>
+    <div class="site-footer__bottom">
+      <div class="site-footer__brand">
+        <a class="brand brand--footer" href="/">Harmony Sheets</a>
+        <p class="site-footer__copy">© <span id="year"></span> Harmony Sheets. All rights reserved.</p>
+        <p class="site-footer__tagline">One-time purchase. No subscriptions.</p>
+      </div>
+      <div class="site-footer__extras">
+        <p class="site-footer__locale">Serving customers worldwide • USD</p>
+        <div class="site-footer__payments">
+          <span class="site-footer__payment">Visa</span>
+          <span class="site-footer__payment">Mastercard</span>
+          <span class="site-footer__payment">Amex</span>
+          <span class="site-footer__payment">PayPal</span>
+          <span class="site-footer__payment">Shop Pay</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</footer>
+
+<script src="app.js"></script>
+<script type="module" src="auth.js"></script>
+</body>
+</html>

--- a/style.css
+++ b/style.css
@@ -40,6 +40,8 @@ img{max-width:100%;display:block}
 .nav-link.active{background:rgba(255,255,255,.95);color:var(--nav-link-ink-strong);border-color:#1d4ed8;box-shadow:0 12px 26px rgba(37,99,235,.18)}
 .nav-link--icon{position:relative;padding-right:20px}
 .nav-link--icon.has-items{color:#1d4ed8}
+.nav-link--account{background:rgba(59,130,246,.12);border-color:rgba(59,130,246,.18);color:#1d4ed8}
+.nav-link--account:hover,.nav-link--account:focus-visible{background:rgba(59,130,246,.18);color:#1e3a8a;border-color:rgba(59,130,246,.28)}
 button.nav-link{border:0;background:transparent;cursor:pointer;font:inherit}
 .nav-link__icon{width:22px;height:22px;display:block}
 .nav-link--icon .cart-count{position:absolute;top:6px;right:6px;min-width:20px;height:20px;padding:0 6px;border-radius:999px;background:#ef4444;color:#fff;font-size:.7rem;font-weight:700;display:inline-flex;align-items:center;justify-content:center;box-shadow:0 6px 12px rgba(239,68,68,.35);opacity:0;transform:translateY(-6px) scale(.7);transition:opacity .2s ease,transform .2s ease}
@@ -808,4 +810,53 @@ details.faq summary{cursor:pointer;font-weight:600}
   .admin-table__tagline{max-width:none}
   .admin-form__header{flex-direction:column;align-items:flex-start}
   .admin-form__header-actions{width:100%;justify-content:flex-start}
+}
+
+/* -----------------------------------------------------
+   Authentication
+----------------------------------------------------- */
+.page-auth main{min-height:100vh;padding:96px 20px 120px;background:linear-gradient(180deg,#f8fafc 0%,#eef2ff 100%)}
+.auth{display:flex;justify-content:center}
+.auth-card{width:min(760px,100%);background:#fff;border-radius:32px;padding:48px;border:1px solid rgba(148,163,184,.24);box-shadow:0 38px 80px rgba(15,23,42,.12);display:grid;gap:32px}
+.auth-card__intro{display:grid;gap:10px;text-align:left}
+.auth-card__intro h1{margin:0;font-size:2.4rem;line-height:1.08;color:#0f172a}
+.auth-card__intro p{margin:0;color:#475569;font-size:1.05rem}
+.auth-tabs{display:flex;gap:12px;align-items:center;flex-wrap:wrap}
+.auth-tab{border-radius:14px;border:1px solid rgba(148,163,184,.26);padding:9px 18px;font-size:.95rem;font-weight:600;background:#f8fafc;color:#1f2937;cursor:pointer;transition:background .2s ease,box-shadow .2s ease,color .2s ease;border-bottom:2px solid transparent}
+.auth-tab.is-active,.auth-tab[aria-selected="true"]{background:#eef2ff;color:#1d4ed8;border-color:#c7d2fe;box-shadow:0 12px 24px rgba(99,102,241,.18)}
+.auth-tab.auth-tab--ghost{margin-left:auto;background:transparent;border-style:dashed;color:#64748b}
+.auth-tab.auth-tab--ghost.is-active{background:#fff;border-style:solid;color:#1d4ed8}
+.auth-forms{display:grid;gap:24px}
+.auth-form{display:grid;gap:18px}
+.form-field{display:grid;gap:8px}
+.form-field label{font-weight:600;color:#0f172a}
+.form-field input{border:1px solid rgba(148,163,184,.4);border-radius:12px;padding:12px 14px;font:inherit;background:#f8fafc;transition:border-color .2s ease,box-shadow .2s ease}
+.form-field input:focus-visible{outline:2px solid #6366f1;outline-offset:2px;background:#fff}
+.form-hint{margin:0;font-size:.82rem;color:#64748b}
+.auth-submit{justify-self:flex-start;padding:12px 24px;font-weight:700}
+.auth-status{margin:0;font-weight:600;font-size:.96rem;min-height:1.4em}
+.auth-status[data-state="success"]{color:#16a34a}
+.auth-status[data-state="error"]{color:#dc2626}
+.auth-status[data-state="info"]{color:#2563eb}
+.auth-benefits{padding:26px;border-radius:22px;background:linear-gradient(160deg,rgba(99,102,241,.08),rgba(14,165,233,.08));border:1px solid rgba(99,102,241,.18);display:grid;gap:14px}
+.auth-benefits h2{margin:0;font-size:1.35rem;color:#1e1b4b}
+.auth-benefits ul{margin:0;padding-left:20px;color:#374151;display:grid;gap:8px;font-size:.98rem}
+.auth-benefits__note{margin:0;font-size:.85rem;color:#475569}
+.auth-tab[disabled]{opacity:.4;cursor:not-allowed}
+.auth-form[aria-hidden="true"]{display:none}
+
+@media (max-width:720px){
+  .page-auth main{padding:72px 16px 100px}
+  .auth-card{padding:32px;border-radius:28px}
+  .auth-card__intro h1{font-size:2rem}
+  .auth-tabs{gap:8px}
+  .auth-tab{flex:1 1 calc(50% - 8px);text-align:center}
+  .auth-tab.auth-tab--ghost{flex:1 1 100%;margin-left:0}
+}
+
+@media (max-width:480px){
+  .auth-card{padding:28px;border-radius:24px}
+  .auth-card__intro h1{font-size:1.8rem}
+  .auth-card__intro p{font-size:.98rem}
+  .auth-submit{width:100%}
 }

--- a/supabase-config.example.js
+++ b/supabase-config.example.js
@@ -1,0 +1,13 @@
+export const SUPABASE_URL = "YOUR_SUPABASE_URL";
+export const SUPABASE_ANON_KEY = "YOUR_SUPABASE_ANON_KEY";
+
+export function isSupabaseConfigured() {
+  return (
+    typeof SUPABASE_URL === "string" &&
+    SUPABASE_URL.startsWith("http") &&
+    typeof SUPABASE_ANON_KEY === "string" &&
+    SUPABASE_ANON_KEY.length > 20 &&
+    !SUPABASE_URL.includes("YOUR_SUPABASE") &&
+    !SUPABASE_ANON_KEY.includes("YOUR_SUPABASE")
+  );
+}

--- a/supabase-config.js
+++ b/supabase-config.js
@@ -1,0 +1,13 @@
+export const SUPABASE_URL = "YOUR_SUPABASE_URL";
+export const SUPABASE_ANON_KEY = "YOUR_SUPABASE_ANON_KEY";
+
+export function isSupabaseConfigured() {
+  return (
+    typeof SUPABASE_URL === "string" &&
+    SUPABASE_URL.startsWith("http") &&
+    typeof SUPABASE_ANON_KEY === "string" &&
+    SUPABASE_ANON_KEY.length > 20 &&
+    !SUPABASE_URL.includes("YOUR_SUPABASE") &&
+    !SUPABASE_ANON_KEY.includes("YOUR_SUPABASE")
+  );
+}


### PR DESCRIPTION
## Summary
- add a dedicated login.html experience with Supabase-powered sign-in, freemium sign-up, and password reset flows
- implement a lightweight auth.js module that talks to Supabase, handles recovery tokens, and manages UI state when credentials are missing
- surface an account access link in the global navigation, add supporting styles, and document Supabase setup steps plus configuration stubs

## Testing
- python3 -m http.server 8000


------
https://chatgpt.com/codex/tasks/task_e_68e500fa59e8832dafbca7c9c3ea4e31